### PR TITLE
Update Robolectric 3.2.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -154,7 +154,7 @@ dependencies {
 
     // Test
     testCompile 'junit:junit:4.12'
-    testCompile "org.robolectric:robolectric:3.1.1"
+    testCompile "org.robolectric:robolectric:3.2.2"
     testCompile('com.squareup.assertj:assertj-android:1.1.1') {
         exclude group: 'com.android.support', module: 'support-annotations'
     }

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/util/DateUtil.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/util/DateUtil.java
@@ -23,6 +23,10 @@ public class DateUtil {
 
     private static final String FORMAT_PROGRAM_START_DATE = "MM/dd(E) kk:mm";
 
+    private DateUtil() {
+        throw new AssertionError("no instance!");
+    }
+
     @NonNull
     public static String getMonthDate(Date date, Context context) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {

--- a/app/src/test/java/io/github/droidkaigi/confsched2017/ExampleUnitTest.java
+++ b/app/src/test/java/io/github/droidkaigi/confsched2017/ExampleUnitTest.java
@@ -1,6 +1,8 @@
 package io.github.droidkaigi.confsched2017;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertEquals;
 
@@ -9,6 +11,7 @@ import static org.junit.Assert.assertEquals;
  *
  * @see <a href="http://d.android.com/tools/testing">Testing documentation</a>
  */
+@RunWith(RobolectricTestRunner.class)
 public class ExampleUnitTest {
 
     @Test

--- a/app/src/test/java/io/github/droidkaigi/confsched2017/util/DateUtilTest.java
+++ b/app/src/test/java/io/github/droidkaigi/confsched2017/util/DateUtilTest.java
@@ -1,0 +1,41 @@
+package io.github.droidkaigi.confsched2017.util;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Date;
+
+import io.github.droidkaigi.confsched2017.R;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+/**
+ * Created by KeishinYokomaku on 2017/01/17.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class DateUtilTest {
+    @Test
+    public void ctor() throws Exception {
+        // no instance allowed even if creating a new instance via reflection
+        // because this is an utility!
+        try {
+            Constructor<DateUtil> ctor = DateUtil.class.getDeclaredConstructor();
+            ctor.setAccessible(true);
+            ctor.newInstance();
+        } catch (InvocationTargetException e) {
+            if (!(e.getCause() instanceof AssertionError))
+                fail();
+        }
+    }
+
+    @Test
+    public void getMonthDate_nonNull() throws Exception {
+        String month = DateUtil.getMonthDate(new Date(System.currentTimeMillis()), RuntimeEnvironment.application);
+        assertNotNull(month);
+    }
+}

--- a/app/src/test/resources/robolectric.properties
+++ b/app/src/test/resources/robolectric.properties
@@ -1,0 +1,5 @@
+sdk=25
+manifest=AndroidManifest.xml
+packageName=io.github.droidkaigi.confsched2017
+constants=io.github.droidkaigi.confsched2017.BuildConfig
+application=io.github.droidkaigi.confsched2017.MainApplication


### PR DESCRIPTION
Robolectric 3.2.2 supports API 24 and 25 and has some updates in mock PackageManager impl.
We can externalize test env configuration as `robolectric.properties` file instead of using `@Config`.