### PR TITLE
Move the position of google-services plugin at the bottom

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,6 @@ import com.android.ddmlib.DdmPreferences
 
 apply plugin: 'jacoco'
 apply plugin: 'com.android.application'
-apply plugin: 'com.google.gms.google-services'
 apply plugin: 'me.tatarka.retrolambda'
 apply plugin: 'kotlin-android'
 
@@ -296,3 +295,6 @@ task jacocoTestReportDevelop(type: JacocoReport, dependsOn: ['testDevelopDebugUn
         println "jacoco html report has been generated to file://${reports.html.destination}/index.html"
     }
 }
+
+// MUST BE AT THE BOTTOM
+apply plugin: 'com.google.gms.google-services'


### PR DESCRIPTION
## Issue
-

## Overview (Required)
- Move the position of `apply plugin: 'com.google.gms.google-services'` to the bottom of build.gradle
- this is required for Firebase to work properly

## Links
- https://firebase.google.com/docs/android/setup?hl=en

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
