### PR TITLE
set .idea/icon.png to show the icon in Android Studio start window

### DIFF
--- a/.idea/icon.png
+++ b/.idea/icon.png
@@ -1,0 +1,1 @@
+../app/src/main/res/mipmap-xhdpi/ic_launcher.png


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
- `.idea/icon.png` is shown in the IntelliJ IDEA welcome window (see the attached screenshot)

## Links
- N/A

## Screenshot

<img width="771" alt="screen shot 2017-02-06 at 11 24 00" src="https://cloud.githubusercontent.com/assets/101800/22632692/0286e472-ec5f-11e6-8e28-247c8cc56cde.png">
