### PR TITLE
Replace "licence" with "license"

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/InformationFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/InformationFragment.java
@@ -77,7 +77,7 @@ public class InformationFragment extends BaseFragment implements InformationView
     }
 
     @Override
-    public void showLicencePage() {
+    public void showLicensePage() {
         LicensesActivity.start(getActivity());
     }
 

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/InformationViewModel.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/InformationViewModel.java
@@ -50,9 +50,9 @@ public final class InformationViewModel implements ViewModel {
         }
     }
 
-    public void onClickLicence(@SuppressWarnings("unused") View view) {
+    public void onClickLicense(@SuppressWarnings("unused") View view) {
         if (callback != null) {
-            callback.showLicencePage();
+            callback.showLicensePage();
         }
     }
 
@@ -107,7 +107,7 @@ public final class InformationViewModel implements ViewModel {
 
         void showTranslationsPage();
 
-        void showLicencePage();
+        void showLicensePage();
 
         void showDevInfoPage();
 

--- a/app/src/main/res/layout/fragment_information.xml
+++ b/app/src/main/res/layout/fragment_information.xml
@@ -150,9 +150,9 @@
             <io.github.droidkaigi.confsched2017.view.customview.InfoRowView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:onClick="@{viewModel::onClickLicence}"
-                    app:infoDescription="@string/info_licence_description"
-                    app:infoTitle="@string/info_licence_title"
+                    android:onClick="@{viewModel::onClickLicense}"
+                    app:infoDescription="@string/info_license_description"
+                    app:infoTitle="@string/info_license_title"
                     />
 
             <io.github.droidkaigi.confsched2017.view.customview.InfoRowView

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -28,8 +28,8 @@
     <string name="info_sponsors_description">DroidKaigiは多くのスポンサーによってサポートされています。 ありがとうございます！</string>
     <string name="info_questionnaire_title">アンケート</string>
     <string name="info_questionnaire_description">DroidKaigiをより良くするためにアンケートにご協力ください。</string>
-    <string name="info_licence_title">ライセンス</string>
-    <string name="info_licence_description">このアプリは多くの素晴らしいライブラリを利用してます。作者のみなさま、ありがとうございます！</string>
+    <string name="info_license_title">ライセンス</string>
+    <string name="info_license_description">このアプリは多くの素晴らしいライブラリを利用してます。作者のみなさま、ありがとうございます！</string>
     <string name="info_dev_info_title">開発情報</string>
     <!-- Sponsors -->
     <string name="sponsors">スポンサー</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,8 +47,8 @@
     <string name="info_questionnaire_description">Pleare cooperate with the questionnaire to improve DroidKaigi.</string>
     <string name="info_contributors_description">Awesome contributors for this app. you can contribute from https://github.com/DroidKaigi/conference-app-2017</string>
     <string name="info_help_translate">Your contribution is much appreciated! Tap here to contribute.</string>
-    <string name="info_licence_title">Licence</string>
-    <string name="info_licence_description">This app uses many awesome libraries. Thank you so much!</string>
+    <string name="info_license_title">Licenses</string>
+    <string name="info_license_description">This app uses many awesome libraries. Thank you so much!</string>
     <string name="info_dev_info_title">Dev info</string>
 
 


### PR DESCRIPTION
## Issue
-

## Overview (Required)
"licence" and "license" are mixed in project. I think those should be unified.

## Links
- [Licence vs\. License: What’s the Difference? \- Writing Explained](http://writingexplained.org/licence-vs-license-difference)

## Screenshot
Before | After
:--: | :--:
<img src="https://cloud.githubusercontent.com/assets/893643/22636613/f099b156-ec7f-11e6-9ed7-37873d0316d7.png" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/893643/22636629/06afdb46-ec80-11e6-9d5f-e3f4cc525aa4.png" width="300" />
