### PR TITLE
Enable diagonal scroll on the session list without using custom layoutmanager

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/customview/TouchlessTwoWayView.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/customview/TouchlessTwoWayView.java
@@ -1,0 +1,31 @@
+package io.github.droidkaigi.confsched2017.view.customview;
+
+import android.content.Context;
+import android.support.annotation.Nullable;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+
+import org.lucasr.twowayview.widget.TwoWayView;
+
+public class TouchlessTwoWayView extends TwoWayView {
+    public TouchlessTwoWayView(Context context) {
+        this(context, null);
+    }
+
+    public TouchlessTwoWayView(Context context, @Nullable AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public TouchlessTwoWayView(Context context, @Nullable AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+    }
+
+    @Override
+    public boolean dispatchTouchEvent(MotionEvent ev) {
+        return false;
+    }
+
+    public boolean forceToDispatchTouchEvent(MotionEvent ev) {
+        return super.dispatchTouchEvent(ev);
+    }
+}

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SessionsFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SessionsFragment.java
@@ -18,7 +18,9 @@ import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.view.MotionEvent;
 import android.view.View;
+import android.view.ViewConfiguration;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -146,6 +148,24 @@ public class SessionsFragment extends BaseFragment implements SessionViewModel.C
         adapter = new SessionsAdapter(getContext());
         binding.recyclerView.setAdapter(adapter);
 
+        binding.root.setOnTouchListener((v, event) -> {
+            MotionEvent e = MotionEvent.obtain(event);
+            e.setLocation(e.getX() + binding.root.getScrollX(), e.getY() - binding.headerRow.getHeight());
+
+            boolean isScrolling = binding.recyclerView.getScrollState() == RecyclerView.SCROLL_STATE_DRAGGING;
+
+            binding.recyclerView.onTouchEvent(e);
+
+            if (!isScrolling && binding.recyclerView.getScrollState() == RecyclerView.SCROLL_STATE_IDLE
+                    && e.getDownTime() > e.getEventTime() - ViewConfiguration.getTapTimeout() && e.getAction() == MotionEvent.ACTION_UP) {
+                MotionEvent down = MotionEvent.obtain(e);
+                down.setAction(MotionEvent.ACTION_DOWN);
+                binding.recyclerView.forceToDispatchTouchEvent(down);
+                binding.recyclerView.forceToDispatchTouchEvent(e);
+            }
+
+            return false;
+        });
         binding.recyclerView.clearOnScrollListeners();
         binding.recyclerView.addOnScrollListener(new RecyclerView.OnScrollListener() {
             @Override

--- a/app/src/main/res/layout/fragment_sessions.xml
+++ b/app/src/main/res/layout/fragment_sessions.xml
@@ -52,7 +52,7 @@
                         android:background="@color/grey300"
                         />
 
-                <org.lucasr.twowayview.widget.TwoWayView
+                <io.github.droidkaigi.confsched2017.view.customview.TouchlessTwoWayView
                         android:id="@+id/recycler_view"
                         android:layout_width="wrap_content"
                         android:layout_height="match_parent"


### PR DESCRIPTION
## Issue
- Not exact one, but related with https://github.com/DroidKaigi/conference-app-2017/issues/72

## Overview (Required)
- Enable diagonal scroll on the session list to use motion event dispatch/simulate process.

## Known issue
- You couldn't see any effects when pressed a session long

## Links
- None

## Screenshot

![bullheadmmb29qjmatsu02062017191231](https://cloud.githubusercontent.com/assets/4340693/22643119/88b16fae-eca0-11e6-9a3e-6d7bba5abe06.gif)

