### PR TITLE
Fix language tag on SessionDetail

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/model/Session.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/model/Session.java
@@ -14,9 +14,9 @@ import java.util.Date;
 @Table
 public class Session {
 
-    public static final String LANG_EN_ID = "en";
+    public static final String LANG_EN_ID = "EN";
 
-    public static final String LANG_JA_ID = "ja";
+    public static final String LANG_JA_ID = "JA";
 
     @PrimaryKey(auto = false)
     @Column(indexed = true)


### PR DESCRIPTION
## Issue
- None

## Overview (Required)
When transitioning from SessionsFragment to SessionDetailFragment, language tag on SessionDetailFragment unfortunately all became 'English'.

Fixed this tag to become the language of the target session.

## Links
- None

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
