### PR TITLE
add languageId default value

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/SessionViewModel.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/SessionViewModel.java
@@ -53,6 +53,8 @@ public class SessionViewModel extends BaseObservable implements ViewModel {
 
     private int normalSessionItemVisibility;
 
+    private int languageVisibility;
+
     private Callback callback;
 
     SessionViewModel(@NonNull Session session, Context context, int roomCount, boolean isMySession) {
@@ -67,8 +69,10 @@ public class SessionViewModel extends BaseObservable implements ViewModel {
         if (session.room != null) {
             this.roomName = session.room.name;
         }
-       
-        this.languageId = session.lang != null ? session.lang.toUpperCase() : Session.LANG_EN_ID;
+        if (session.lang != null) {
+            this.languageId = session.lang.toUpperCase();
+        }
+        this.languageVisibility = session.lang != null ? View.VISIBLE : View.GONE;
 
         this.minutes = context.getString(R.string.session_minutes, session.durationMin);
 
@@ -201,6 +205,10 @@ public class SessionViewModel extends BaseObservable implements ViewModel {
 
     public int getNormalSessionItemVisibility() {
         return normalSessionItemVisibility;
+    }
+
+    public int getLanguageVisibility() {
+        return languageVisibility;
     }
 
     @Bindable

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/SessionViewModel.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/SessionViewModel.java
@@ -67,9 +67,8 @@ public class SessionViewModel extends BaseObservable implements ViewModel {
         if (session.room != null) {
             this.roomName = session.room.name;
         }
-        if (session.lang != null) {
-            this.languageId = session.lang.toUpperCase();
-        }
+       
+        this.languageId = session.lang != null ? session.lang.toUpperCase() : Session.LANG_EN_ID;
 
         this.minutes = context.getString(R.string.session_minutes, session.durationMin);
 

--- a/app/src/main/res/layout/view_session_cell.xml
+++ b/app/src/main/res/layout/view_session_cell.xml
@@ -120,7 +120,7 @@
                 android:textAppearance="@style/TextCaption"
                 android:textColor="@color/grey500"
                 android:textSize="@dimen/session_table_cell_title_text_size"
-                android:visibility="@{viewModel.normalSessionItemVisibility}"
+                android:visibility="@{viewModel.languageVisibility}"
                 />
 
         <TextView


### PR DESCRIPTION
## Issue
- None

## Overview (Required)
- AfterParty's language text is empty, I add default value to 'languageId' in SessionViewModel.

## Links
-

## Screenshot
Before | After
:--: | :--:
![device-2017-02-06-205946](https://cloud.githubusercontent.com/assets/4988795/22646413/af1411d8-ecaf-11e6-9509-d5c15a748cd4.png) |![device-2017-02-06-205835](https://cloud.githubusercontent.com/assets/4988795/22646426/be5230b2-ecaf-11e6-9a47-e41fae322ca2.png)


