### PR TITLE
move TopicColor to viewmodel

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/SessionDetailViewModel.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/SessionDetailViewModel.java
@@ -17,7 +17,6 @@ import javax.inject.Inject;
 
 import io.github.droidkaigi.confsched2017.R;
 import io.github.droidkaigi.confsched2017.model.Session;
-import io.github.droidkaigi.confsched2017.model.TopicColor;
 import io.github.droidkaigi.confsched2017.repository.sessions.MySessionsRepository;
 import io.github.droidkaigi.confsched2017.repository.sessions.SessionsRepository;
 import io.github.droidkaigi.confsched2017.util.AlarmUtil;

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/SessionViewModel.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/SessionViewModel.java
@@ -12,7 +12,6 @@ import java.util.Date;
 
 import io.github.droidkaigi.confsched2017.R;
 import io.github.droidkaigi.confsched2017.model.Session;
-import io.github.droidkaigi.confsched2017.model.TopicColor;
 import io.github.droidkaigi.confsched2017.util.DateUtil;
 
 public class SessionViewModel extends BaseObservable implements ViewModel {

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/TopicColor.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/TopicColor.java
@@ -1,12 +1,13 @@
-package io.github.droidkaigi.confsched2017.model;
+package io.github.droidkaigi.confsched2017.viewmodel;
 
 import android.support.annotation.ColorRes;
 import android.support.annotation.Nullable;
 import android.support.annotation.StyleRes;
 
 import io.github.droidkaigi.confsched2017.R;
+import io.github.droidkaigi.confsched2017.model.Topic;
 
-public enum TopicColor {
+enum TopicColor {
 
     PRODUCTIVITY_AND_TOOLING(1, R.color.light_green_alpha_15, R.color.light_green_alpha_50,
             R.color.light_green, R.style.AppTheme_NoActionBar_LightGreen),


### PR DESCRIPTION
## Issue
-

## Overview (Required)

`TopicColor` contains styles, colors, and so on. 
I think it should not be a model, but a view-model. In fact `TopicColor` is used only by some view-models.

This PR just moves `TopicColor` into the `viewmodel` package :)

## Links
-

## Screenshot

Nothing changed, because of just a refactoring.