### PR TITLE
Add unit test for sessions repository

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/repository/sessions/SessionsLocalDataSource.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/repository/sessions/SessionsLocalDataSource.java
@@ -45,9 +45,7 @@ public final class SessionsLocalDataSource implements SessionsDataSource {
 
     @Override
     public Single<List<Session>> findAll(String languageId) {
-        return sessionRelation().selector().executeAsObservable().toList()
-                .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread());
+        return sessionRelation().selector().executeAsObservable().toList();
     }
 
     @Override

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/repository/sessions/SessionsRemoteDataSource.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/repository/sessions/SessionsRemoteDataSource.java
@@ -11,8 +11,10 @@ import javax.inject.Inject;
 import io.github.droidkaigi.confsched2017.api.DroidKaigiClient;
 import io.github.droidkaigi.confsched2017.model.Session;
 import io.reactivex.Maybe;
+import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.functions.Function;
 import io.reactivex.schedulers.Schedulers;
 
 public final class SessionsRemoteDataSource implements SessionsDataSource {
@@ -40,10 +42,11 @@ public final class SessionsRemoteDataSource implements SessionsDataSource {
 
     @Override
     public Maybe<Session> find(int sessionId, String languageId) {
-        return findAll(languageId).map(sessions -> Stream.of(sessions)
+        return findAll(languageId)
+                .toObservable()
+                .flatMap(Observable::fromIterable)
                 .filter(session -> session.id == sessionId)
-                .findSingle()
-                .get()).toMaybe();
+                .singleElement();
     }
 
     @Override

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/repository/sessions/SessionsRemoteDataSource.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/repository/sessions/SessionsRemoteDataSource.java
@@ -35,9 +35,7 @@ public final class SessionsRemoteDataSource implements SessionsDataSource {
                         }
                     }
                     return sessions;
-                })
-                .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread());
+                });
     }
 
     @Override

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/repository/sessions/SessionsRepository.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/repository/sessions/SessionsRepository.java
@@ -1,5 +1,7 @@
 package io.github.droidkaigi.confsched2017.repository.sessions;
 
+import android.support.annotation.VisibleForTesting;
+
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -19,7 +21,7 @@ public class SessionsRepository implements SessionsDataSource {
 
     private final SessionsDataSource remoteDataSource;
 
-    private Map<Integer, Session> cachedSessions;
+    @VisibleForTesting Map<Integer, Session> cachedSessions;
 
     private boolean isDirty;
 
@@ -33,7 +35,7 @@ public class SessionsRepository implements SessionsDataSource {
 
     @Override
     public Single<List<Session>> findAll(String languageId) {
-        if (cachedSessions != null && !cachedSessions.isEmpty() && !isDirty) {
+        if (hasCacheSessions()) {
             return Single.create(emitter -> {
                 try {
                     emitter.onSuccess(new ArrayList<>(cachedSessions.values()));
@@ -109,4 +111,9 @@ public class SessionsRepository implements SessionsDataSource {
     public void setIdDirty(boolean isDirty) {
         this.isDirty = isDirty;
     }
+
+    boolean hasCacheSessions() {
+        return cachedSessions != null && !cachedSessions.isEmpty() && !isDirty;
+    }
+
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/repository/sessions/SessionsRepository.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/repository/sessions/SessionsRepository.java
@@ -54,7 +54,7 @@ public class SessionsRepository implements SessionsDataSource {
 
     @Override
     public Maybe<Session> find(int sessionId, String languageId) {
-        if (cachedSessions != null && cachedSessions.containsKey(sessionId) && !isDirty) {
+        if (hasCacheSession(sessionId)) {
             return Maybe.create(emitter -> {
                 try {
                     emitter.onSuccess(cachedSessions.get(sessionId));
@@ -114,6 +114,10 @@ public class SessionsRepository implements SessionsDataSource {
 
     boolean hasCacheSessions() {
         return cachedSessions != null && !cachedSessions.isEmpty() && !isDirty;
+    }
+
+    boolean hasCacheSession(int sessionId) {
+        return cachedSessions != null && cachedSessions.containsKey(sessionId) && !isDirty;
     }
 
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SearchFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SearchFragment.java
@@ -35,6 +35,8 @@ import io.github.droidkaigi.confsched2017.view.customview.BindingHolder;
 import io.github.droidkaigi.confsched2017.view.customview.itemdecoration.DividerItemDecoration;
 import io.github.droidkaigi.confsched2017.viewmodel.SearchResultViewModel;
 import io.github.droidkaigi.confsched2017.viewmodel.SearchViewModel;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.schedulers.Schedulers;
 
 public class SearchFragment extends BaseFragment implements SearchViewModel.Callback, SearchResultViewModel.Callback {
 
@@ -129,6 +131,8 @@ public class SearchFragment extends BaseFragment implements SearchViewModel.Call
 
     private void loadData() {
         viewModel.getSearchResultViewModels(getContext(), this)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                         searchResultViewModels -> adapter.setAllList(searchResultViewModels),
                         throwable -> Log.e(TAG, "Search result load failed.", throwable)

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SessionDetailFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SessionDetailFragment.java
@@ -22,8 +22,10 @@ import io.github.droidkaigi.confsched2017.databinding.FragmentSessionDetailBindi
 import io.github.droidkaigi.confsched2017.view.activity.SessionFeedbackActivity;
 import io.github.droidkaigi.confsched2017.view.helper.AnimationHelper;
 import io.github.droidkaigi.confsched2017.viewmodel.SessionDetailViewModel;
+import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.schedulers.Schedulers;
 
 public class SessionDetailFragment extends BaseFragment implements SessionDetailViewModel.Callback {
 
@@ -54,6 +56,8 @@ public class SessionDetailFragment extends BaseFragment implements SessionDetail
         super.onCreate(savedInstanceState);
         sessionId = getArguments().getInt(ARG_SESSION_ID);
         Disposable disposable = viewModel.findSession(sessionId)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                         session -> initTheme(),
                         throwable -> Log.e(TAG, "Failed to find session.", throwable)

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SessionFeedbackFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SessionFeedbackFragment.java
@@ -12,8 +12,10 @@ import javax.inject.Inject;
 
 import io.github.droidkaigi.confsched2017.databinding.FragmentSessionFeedbackBinding;
 import io.github.droidkaigi.confsched2017.viewmodel.SessionFeedbackViewModel;
+import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.schedulers.Schedulers;
 
 public class SessionFeedbackFragment extends BaseFragment {
 
@@ -63,6 +65,8 @@ public class SessionFeedbackFragment extends BaseFragment {
 
     private void initView() {
         Disposable disposable = viewModel.findSession(sessionId)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                         session -> {
                             // TODO

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SessionsFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SessionsFragment.java
@@ -113,13 +113,14 @@ public class SessionsFragment extends BaseFragment implements SessionViewModel.C
     @Override
     public void onStop() {
         super.onStop();
-        compositeDisposable.dispose();
+        compositeDisposable.clear();
     }
 
     @Override
     public void onDestroy() {
         super.onDestroy();
         viewModel.destroy();
+        compositeDisposable.dispose();
     }
 
     private int getScreenWidth() {

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SessionsFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SessionsFragment.java
@@ -42,8 +42,10 @@ import io.github.droidkaigi.confsched2017.view.customview.ArrayRecyclerAdapter;
 import io.github.droidkaigi.confsched2017.view.customview.BindingHolder;
 import io.github.droidkaigi.confsched2017.viewmodel.SessionViewModel;
 import io.github.droidkaigi.confsched2017.viewmodel.SessionsViewModel;
+import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.schedulers.Schedulers;
 import timber.log.Timber;
 
 public class SessionsFragment extends BaseFragment implements SessionViewModel.Callback {
@@ -125,6 +127,8 @@ public class SessionsFragment extends BaseFragment implements SessionViewModel.C
     private void showSessions() {
         String languageId = Locale.getDefault().getLanguage().toLowerCase();
         Disposable disposable = viewModel.getSessions(languageId, getContext())
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                         this::renderSessions,
                         throwable -> Timber.tag(TAG).e(throwable, "Failed to show sessions.")

--- a/app/src/test/java/io/github/droidkaigi/confsched2017/repository/sessions/SessionsRepositoryTest.kt
+++ b/app/src/test/java/io/github/droidkaigi/confsched2017/repository/sessions/SessionsRepositoryTest.kt
@@ -173,6 +173,27 @@ class SessionsRepositoryTest {
         }
     }
 
+    @Test
+    fun findRemoteRequestNotFound() {
+        val sessions = listOf(createSession(1), createSession(2))
+        val client = mockDroidKaigiClient(sessions)
+
+        val repository = SessionsRepository(
+                SessionsLocalDataSource(mock()),
+                SessionsRemoteDataSource(client)
+        )
+
+        repository.find(3, Session.LANG_JA_ID)
+                .test()
+                .run {
+                    assertNoErrors()
+                    assertNoValues()
+                    assertComplete()
+                }
+    }
+
+    fun createSession(sessionId: Int) = Session().apply { id = sessionId }
+
     fun mockDroidKaigiClient(sessions: List<Session>) = mock<DroidKaigiClient>().apply {
         getSessions(anyString()).invoked.thenReturn(
                 Single.just(sessions)

--- a/app/src/test/java/io/github/droidkaigi/confsched2017/repository/sessions/SessionsRepositoryTest.kt
+++ b/app/src/test/java/io/github/droidkaigi/confsched2017/repository/sessions/SessionsRepositoryTest.kt
@@ -124,6 +124,55 @@ class SessionsRepositoryTest {
                 }
     }
 
+    @Test
+    fun hasCacheSession() {
+        // false cachedSessions is null
+        run {
+            val repository = SessionsRepository(
+                    SessionsLocalDataSource(mock()),
+                    SessionsRemoteDataSource(mock())
+            )
+
+            assertThat(repository.hasCacheSession(0)).isFalse()
+        }
+
+        // false sessionId not found
+        run {
+            val repository = SessionsRepository(
+                    SessionsLocalDataSource(mock()),
+                    SessionsRemoteDataSource(mock())
+            )
+            repository.cachedSessions = mapOf(1 to Session())
+            repository.setIdDirty(false)
+
+            assertThat(repository.hasCacheSession(0)).isFalse()
+        }
+
+        // false dirty
+        run {
+            val repository = SessionsRepository(
+                    SessionsLocalDataSource(mock()),
+                    SessionsRemoteDataSource(mock())
+            )
+            repository.cachedSessions = mapOf(1 to Session())
+            repository.setIdDirty(true)
+
+            assertThat(repository.hasCacheSession(1)).isFalse()
+        }
+
+        // true
+        run {
+            val repository = SessionsRepository(
+                    SessionsLocalDataSource(mock()),
+                    SessionsRemoteDataSource(mock())
+            )
+            repository.cachedSessions = mapOf(1 to Session())
+            repository.setIdDirty(false)
+
+            assertThat(repository.hasCacheSession(1)).isTrue()
+        }
+    }
+
     fun mockDroidKaigiClient(sessions: List<Session>) = mock<DroidKaigiClient>().apply {
         getSessions(anyString()).invoked.thenReturn(
                 Single.just(sessions)

--- a/app/src/test/java/io/github/droidkaigi/confsched2017/repository/sessions/SessionsRepositoryTest.kt
+++ b/app/src/test/java/io/github/droidkaigi/confsched2017/repository/sessions/SessionsRepositoryTest.kt
@@ -11,7 +11,6 @@ import io.reactivex.Single
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.*
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
@@ -49,7 +48,7 @@ class SessionsRepositoryTest {
         val sessions = listOf(Session())
         val client = mockDroidKaigiClient(sessions)
         val ormaDatabase = mock<OrmaDatabase>().apply {
-            transactionAsCompletable(ArgumentMatchers.any()).invoked.thenReturn(Completable.complete())
+            transactionAsCompletable(any()).invoked.thenReturn(Completable.complete())
         }
         val cachedSessions: Map<Int, Session> = spy(mutableMapOf())
 
@@ -69,7 +68,7 @@ class SessionsRepositoryTest {
                     assertComplete()
 
                     client.verify().getSessions(eq(Session.LANG_JA_ID))
-                    ormaDatabase.verify().transactionAsCompletable(ArgumentMatchers.any())
+                    ormaDatabase.verify().transactionAsCompletable(any())
                     cachedSessions.verify(never()).values
                 }
 
@@ -126,7 +125,7 @@ class SessionsRepositoryTest {
     }
 
     fun mockDroidKaigiClient(sessions: List<Session>) = mock<DroidKaigiClient>().apply {
-        getSessions(ArgumentMatchers.anyString()).invoked.thenReturn(
+        getSessions(anyString()).invoked.thenReturn(
                 Single.just(sessions)
         )
     }

--- a/app/src/test/java/io/github/droidkaigi/confsched2017/repository/sessions/SessionsRepositoryTest.kt
+++ b/app/src/test/java/io/github/droidkaigi/confsched2017/repository/sessions/SessionsRepositoryTest.kt
@@ -1,11 +1,20 @@
 package io.github.droidkaigi.confsched2017.repository.sessions
 
+import com.sys1yagi.kmockito.invoked
 import com.sys1yagi.kmockito.mock
+import com.sys1yagi.kmockito.verify
+import io.github.droidkaigi.confsched2017.api.DroidKaigiClient
+import io.github.droidkaigi.confsched2017.model.OrmaDatabase
 import io.github.droidkaigi.confsched2017.model.Session
+import io.reactivex.Completable
+import io.reactivex.Single
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito.*
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class SessionsRepositoryTest {
@@ -34,4 +43,92 @@ class SessionsRepositoryTest {
             assertThat(repository.hasCacheSessions()).isTrue()
         }
     }
+
+    @Test
+    fun findAllRemoteRequestAndLocalCache() {
+        val sessions = listOf(Session())
+        val client = mockDroidKaigiClient(sessions)
+        val ormaDatabase = mock<OrmaDatabase>().apply {
+            transactionAsCompletable(ArgumentMatchers.any()).invoked.thenReturn(Completable.complete())
+        }
+        val cachedSessions: Map<Int, Session> = spy(mutableMapOf())
+
+        val repository = SessionsRepository(
+                SessionsLocalDataSource(ormaDatabase),
+                SessionsRemoteDataSource(client)
+        ).apply {
+            this.cachedSessions = cachedSessions
+        }
+
+        // TODO I want to use enum for language id.
+        repository.findAll(Session.LANG_JA_ID)
+                .test()
+                .run {
+                    assertNoErrors()
+                    assertResult(sessions)
+                    assertComplete()
+
+                    client.verify().getSessions(eq(Session.LANG_JA_ID))
+                    ormaDatabase.verify().transactionAsCompletable(ArgumentMatchers.any())
+                    cachedSessions.verify(never()).values
+                }
+
+        repository.findAll(Session.LANG_JA_ID)
+                .test()
+                .run {
+                    assertNoErrors()
+                    assertThat(values().first().size).isEqualTo(1)
+                    assertComplete()
+
+                    cachedSessions.verify().values
+                }
+    }
+
+    @Test
+    fun findAllLocalCache() {
+        val sessions = listOf(Session())
+        val client = mockDroidKaigiClient(sessions)
+        val ormaDatabase = OrmaDatabase
+                .builder(RuntimeEnvironment.application)
+                .name(null)
+                .build()
+        val cachedSessions: Map<Int, Session> = mock()
+
+        val repository = SessionsRepository(
+                SessionsLocalDataSource(ormaDatabase),
+                SessionsRemoteDataSource(client)
+        ).apply {
+            this.cachedSessions = cachedSessions
+        }
+
+        repository.findAll(Session.LANG_JA_ID)
+                .test()
+                .run {
+                    assertNoErrors()
+                    assertResult(sessions)
+                    assertComplete()
+
+                    client.verify().getSessions(eq(Session.LANG_JA_ID))
+                    cachedSessions.verify(never()).values
+                }
+
+        repository.setIdDirty(true)
+
+        repository.findAll(Session.LANG_JA_ID)
+                .test()
+                .run {
+                    assertNoErrors()
+                    assertThat(values().first().size).isEqualTo(1)
+                    assertComplete()
+
+                    cachedSessions.verify(never()).values
+                }
+    }
+
+    fun mockDroidKaigiClient(sessions: List<Session>) = mock<DroidKaigiClient>().apply {
+        getSessions(ArgumentMatchers.anyString()).invoked.thenReturn(
+                Single.just(sessions)
+        )
+    }
+
 }

--- a/app/src/test/java/io/github/droidkaigi/confsched2017/repository/sessions/SessionsRepositoryTest.kt
+++ b/app/src/test/java/io/github/droidkaigi/confsched2017/repository/sessions/SessionsRepositoryTest.kt
@@ -1,0 +1,37 @@
+package io.github.droidkaigi.confsched2017.repository.sessions
+
+import com.sys1yagi.kmockito.mock
+import io.github.droidkaigi.confsched2017.model.Session
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SessionsRepositoryTest {
+
+    @Test
+    fun hasCacheSessions() {
+        // false
+        run {
+            val repository = SessionsRepository(
+                    SessionsLocalDataSource(mock()),
+                    SessionsRemoteDataSource(mock())
+            )
+
+            assertThat(repository.hasCacheSessions()).isFalse()
+        }
+
+        // true
+        run {
+            val repository = SessionsRepository(
+                    SessionsLocalDataSource(mock()),
+                    SessionsRemoteDataSource(mock())
+            )
+            repository.cachedSessions = mapOf(0 to Session())
+            repository.setIdDirty(false)
+
+            assertThat(repository.hasCacheSessions()).isTrue()
+        }
+    }
+}

--- a/app/src/test/java/io/github/droidkaigi/confsched2017/repository/sessions/SessionsRepositoryTest.kt
+++ b/app/src/test/java/io/github/droidkaigi/confsched2017/repository/sessions/SessionsRepositoryTest.kt
@@ -20,7 +20,7 @@ class SessionsRepositoryTest {
 
     @Test
     fun hasCacheSessions() {
-        // false
+        // false. cache is null.
         run {
             val repository = SessionsRepository(
                     SessionsLocalDataSource(mock()),
@@ -30,7 +30,19 @@ class SessionsRepositoryTest {
             assertThat(repository.hasCacheSessions()).isFalse()
         }
 
-        // true
+        // false. repository has any cached session, but repository is dirty.
+        run {
+            val repository = SessionsRepository(
+                    SessionsLocalDataSource(mock()),
+                    SessionsRemoteDataSource(mock())
+            )
+            repository.cachedSessions = mapOf(0 to Session())
+            repository.setIdDirty(true)
+
+            assertThat(repository.hasCacheSessions()).isFalse()
+        }
+
+        // true.
         run {
             val repository = SessionsRepository(
                     SessionsLocalDataSource(mock()),


### PR DESCRIPTION
## Issue

Add test for SessionsRepository #96

## Overview (Required)

- Add SessionsRepositoryTest and a first test for hasCacheSessions(). 	27ce6ac
- Move subscribeOn and observeOn calls from the data source to where we actually use each Observable. 102e6a9
- Add tests for `SessionsRepository.findAll()`. 102e6a9
- Add hasSession(int) and test.			5ef2fd2
- Fix SessionsRemoteDataSource.find(int, String).  d36bfae
- Add tests for find(int, String). bf8d36d

## Links

None

## Screenshot

None

## Todo

- [x] Discuss about Observable thread control
- [x] Add test for `find()`
- [x] update description
- [x] fix local cache test.
