### PR TITLE
Add security config(Enforcing https)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
             android:label="@string/app_name"
             android:supportsRtl="true"
             android:theme="@style/AppTheme.ColoredStatusBar"
+            android:networkSecurityConfig="@xml/network_security_config"
             >
         <activity
                 android:name=".view.activity.MainActivity"

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <domain-config cleartextTrafficPermitted="false">
-        <domain includeSubdomains="true">raw.githubusercontent.com</domain>
-    </domain-config>
+    <base-config cleartextTrafficPermitted="false">
+                <!-- add more config here-->
+    </base-config>
 </network-security-config>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="false" />
+</network-security-config>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <domain-config cleartextTrafficPermitted="false" />
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="true">raw.githubusercontent.com</domain>
+    </domain-config>
 </network-security-config>


### PR DESCRIPTION
## Issue
- Not an issue, but https is more secure and SEO-friendly comparing to http.

## Overview (Required)
- All outbound network traffic originated from the app are bounded in HTTPS. App can no longer access by http.

## Links
-https://developer.android.com/reference/android/security/NetworkSecurityPolicy.html#isCleartextTrafficPermitted()
- https://developer.android.com/training/articles/security-config.html#CleartextTrafficPermitted

## Screenshot
No change in images.