### PR TITLE
Use kapt

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -166,6 +166,7 @@ android {
 configurations {
     all {
         resolutionStrategy {
+            force "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
             force "com.android.support:support-annotations:${support_lib_version}"
         }
     }
@@ -175,7 +176,7 @@ kapt {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:1.0.6"
+    compile "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
 
     // Support Library
     compile "com.android.support:support-v4:${support_lib_version}"
@@ -243,9 +244,9 @@ dependencies {
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
     androidTestCompile 'com.android.support.test.espresso:espresso-intents:2.2.2'
     testCompile 'junit:junit:4.12'
-    testCompile "org.jetbrains.kotlin:kotlin-test-junit:1.0.6"
-    testCompile('com.taroid.knit:knit:0.1.2') { exclude module:"kotlin-stdlib" }
-    testCompile('com.github.sys1yagi:kmockito:0.1.2') { exclude module:"kotlin-stdlib" }
+    testCompile "org.jetbrains.kotlin:kotlin-test-junit:${kotlin_version}"
+    testCompile 'com.taroid.knit:knit:0.1.2'
+    testCompile 'com.github.sys1yagi:kmockito:0.1.2'
 }
 
 jacoco {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -170,8 +170,13 @@ configurations {
         }
     }
 }
+kapt {
+    generateStubs = true
+}
 
 dependencies {
+    compile "org.jetbrains.kotlin:kotlin-stdlib:1.0.6"
+
     // Support Library
     compile "com.android.support:support-v4:${support_lib_version}"
     compile "com.android.support:appcompat-v7:${support_lib_version}"
@@ -195,12 +200,13 @@ dependencies {
 
     // Structure
     compile 'com.google.dagger:dagger:2.7'
-    annotationProcessor 'com.google.dagger:dagger-compiler:2.7'
+    kapt 'com.google.dagger:dagger-compiler:2.7'
     provided 'javax.annotation:jsr250-api:1.0'
     compile 'io.reactivex.rxjava2:rxjava:2.0.2'
     compile 'io.reactivex.rxjava2:rxandroid:2.0.1'
     compile 'com.annimon:stream:1.1.4'
     compile 'uk.co.chrisjenx:calligraphy:2.2.0'
+    kapt 'com.android.databinding:compiler:2.2.2'
 
     // Android Utility
     compile 'com.deploygate:sdk:3.1.1'
@@ -209,10 +215,10 @@ dependencies {
     debugCompile 'com.facebook.stetho:stetho-okhttp3:1.4.2'
     debugCompile 'com.facebook.stetho:stetho-timber:1.4.2@aar'
     compile 'com.squareup.picasso:picasso:2.5.2'
-    annotationProcessor 'com.github.gfx.android.orma:orma-processor:4.1.0'
+    kapt 'com.github.gfx.android.orma:orma-processor:4.1.0'
     compile 'com.github.gfx.android.orma:orma:4.1.0'
     compile 'com.rejasupotaro:kvs-schema:5.0.1'
-    annotationProcessor 'com.rejasupotaro:kvs-schema-compiler:5.0.1'
+    kapt 'com.rejasupotaro:kvs-schema-compiler:5.0.1'
 
     // UI
     compile 'org.lucasr.twowayview:core:1.0.0-SNAPSHOT@aar'
@@ -237,10 +243,9 @@ dependencies {
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
     androidTestCompile 'com.android.support.test.espresso:espresso-intents:2.2.2'
     testCompile 'junit:junit:4.12'
-    testCompile "org.jetbrains.kotlin:kotlin-stdlib:1.0.6"
     testCompile "org.jetbrains.kotlin:kotlin-test-junit:1.0.6"
-    testCompile 'com.taroid.knit:knit:0.1.2'
-    testCompile 'com.github.sys1yagi:kmockito:0.1.2'
+    testCompile('com.taroid.knit:knit:0.1.2') { exclude module:"kotlin-stdlib" }
+    testCompile('com.github.sys1yagi:kmockito:0.1.2') { exclude module:"kotlin-stdlib" }
 }
 
 jacoco {

--- a/app/licenses.yml
+++ b/app/licenses.yml
@@ -138,11 +138,7 @@
   licence: The Apache Software License, Version 2.0
   licenseUrl: http://www.apache.org/licenses/LICENSE-2.0.txt
   url: https://github.com/DeployGate/deploygate-android-sdk
-- artifact: org.jetbrains.kotlin:kotlin-runtime:+
-  name: kotlin-runtime
-  copyrightHolder: JetBrains Inc.
-  license: The Apache Software License, Version 2.0
-- artifact: org.jetbrains.kotlin:kotlin-stdlib:+
-  name: kotlin-stdlib
+- artifact: org.jetbrains.kotlin:+:+
+  name: Kotlin Runtime and Standard Library
   copyrightHolder: JetBrains Inc.
   license: The Apache Software License, Version 2.0

--- a/app/licenses.yml
+++ b/app/licenses.yml
@@ -138,3 +138,11 @@
   licence: The Apache Software License, Version 2.0
   licenseUrl: http://www.apache.org/licenses/LICENSE-2.0.txt
   url: https://github.com/DeployGate/deploygate-android-sdk
+- artifact: org.jetbrains.kotlin:kotlin-runtime:+
+  name: kotlin-runtime
+  copyrightHolder: JetBrains Inc.
+  license: The Apache Software License, Version 2.0
+- artifact: org.jetbrains.kotlin:kotlin-stdlib:+
+  name: kotlin-stdlib
+  copyrightHolder: JetBrains Inc.
+  license: The Apache Software License, Version 2.0

--- a/app/src/main/assets/licenses.html
+++ b/app/src/main/assets/licenses.html
@@ -4538,6 +4538,498 @@
     </div>
     <div class="library">
       <!-- https://opensource.org/licenses/Apache-2.0 -->
+      <h1 class="title">kotlin-runtime</h1>
+      <p class="notice">Copyright &copy; JetBrains Inc. All rights reserved.</p>
+      
+      <div class="license">
+        <h2>
+          Apache License
+          <br/>
+          Version 2.0, January 2004
+          <br/>
+          http://www.apache.org/licenses/
+        </h2>
+        <p>TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION</p>
+        <h2>1. Definitions.</h2>
+        <p>
+          "License" shall mean the terms and conditions for use, reproduction,
+          and distribution as defined by Sections 1 through 9 of this document.
+        </p>
+        <p>
+          "Licensor" shall mean the copyright owner or entity authorized by
+          the copyright owner that is granting the License.
+        </p>
+        <p>
+          "Legal Entity" shall mean the union of the acting entity and all
+          other entities that control, are controlled by, or are under common
+          control with that entity. For the purposes of this definition,
+          "control" means (i) the power, direct or indirect, to cause the
+          direction or management of such entity, whether by contract or
+          otherwise, or (ii) ownership of fifty percent (50%) or more of the
+          outstanding shares, or (iii) beneficial ownership of such entity.
+        </p>
+        <p>
+          "You" (or "Your") shall mean an individual or Legal Entity
+          exercising permissions granted by this License.
+        </p>
+        <p>
+          "Source" form shall mean the preferred form for making modifications,
+          including but not limited to software source code, documentation
+          source, and configuration files.
+        </p>
+        <p>
+          "Object" form shall mean any form resulting from mechanical
+          transformation or translation of a Source form, including but
+          not limited to compiled object code, generated documentation,
+          and conversions to other media types.
+        </p>
+        <p>
+          "Work" shall mean the work of authorship, whether in Source or
+          Object form, made available under the License, as indicated by a
+          copyright notice that is included in or attached to the work
+          (an example is provided in the Appendix below).
+        </p>
+        <p>
+          "Derivative Works" shall mean any work, whether in Source or Object
+          form, that is based on (or derived from) the Work and for which the
+          editorial revisions, annotations, elaborations, or other modifications
+          represent, as a whole, an original work of authorship. For the purposes
+          of this License, Derivative Works shall not include works that remain
+          separable from, or merely link (or bind by name) to the interfaces of,
+          the Work and Derivative Works thereof.
+        </p>
+        <p>
+          "Contribution" shall mean any work of authorship, including
+          the original version of the Work and any modifications or additions
+          to that Work or Derivative Works thereof, that is intentionally
+          submitted to Licensor for inclusion in the Work by the copyright owner
+          or by an individual or Legal Entity authorized to submit on behalf of
+          the copyright owner. For the purposes of this definition, "submitted"
+          means any form of electronic, verbal, or written communication sent
+          to the Licensor or its representatives, including but not limited to
+          communication on electronic mailing lists, source code control systems,
+          and issue tracking systems that are managed by, or on behalf of, the
+          Licensor for the purpose of discussing and improving the Work, but
+          excluding communication that is conspicuously marked or otherwise
+          designated in writing by the copyright owner as "Not a Contribution."
+        </p>
+        <p>
+          "Contributor" shall mean Licensor and any individual or Legal Entity
+          on behalf of whom a Contribution has been received by Licensor and
+          subsequently incorporated within the Work.
+        </p>
+        <div class="block">
+          <h2 class="inline">2. Grant of Copyright License.</h2>
+          <p class="inline">
+            Subject to the terms and conditions of
+            this License, each Contributor hereby grants to You a perpetual,
+            worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+            copyright license to reproduce, prepare Derivative Works of,
+            publicly display, publicly perform, sublicense, and distribute the
+            Work and such Derivative Works in Source or Object form.
+          </p>
+        </div>
+        <div class="block">
+          <h2 class="inline">3. Grant of Patent License.</h2>
+          <p class="inline">
+            Subject to the terms and conditions of
+            this License, each Contributor hereby grants to You a perpetual,
+            worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+            (except as stated in this section) patent license to make, have made,
+            use, offer to sell, sell, import, and otherwise transfer the Work,
+            where such license applies only to those patent claims licensable
+            by such Contributor that are necessarily infringed by their
+            Contribution(s) alone or by combination of their Contribution(s)
+            with the Work to which such Contribution(s) was submitted. If You
+            institute patent litigation against any entity (including a
+            cross-claim or counterclaim in a lawsuit) alleging that the Work
+            or a Contribution incorporated within the Work constitutes direct
+            or contributory patent infringement, then any patent licenses
+            granted to You under this License for that Work shall terminate
+            as of the date such litigation is filed.
+          </p>
+        </div>
+        <div class="block">
+          <h2 class="inline">4. Redistribution.</h2>
+          <p class="inline">
+            You may reproduce and distribute copies of the
+            Work or Derivative Works thereof in any medium, with or without
+            modifications, and in Source or Object form, provided that You
+            meet the following conditions:
+          </p>
+        </div>
+        <ul class="low-alpha">
+          <li>
+            You must give any other recipients of the Work or
+            Derivative Works a copy of this License; and
+          </li>
+          <li>
+            You must cause any modified files to carry prominent notices
+            stating that You changed the files; and
+          </li>
+          <li>
+            You must retain, in the Source form of any Derivative Works
+            that You distribute, all copyright, patent, trademark, and
+            attribution notices from the Source form of the Work,
+            excluding those notices that do not pertain to any part of |
+            the Derivative Works; and
+          </li>
+          <li>
+            If the Work includes a "NOTICE" text file as part of its
+            distribution, then any Derivative Works that You distribute must
+            include a readable copy of the attribution notices contained
+            within such NOTICE file, excluding those notices that do not
+            pertain to any part of the Derivative Works, in at least one
+            of the following places: within a NOTICE text file distributed
+            as part of the Derivative Works; within the Source form or
+            documentation, if provided along with the Derivative Works; or,
+            within a display generated by the Derivative Works, if and
+            wherever such third-party notices normally appear. The contents
+            of the NOTICE file are for informational purposes only and
+            do not modify the License. You may add Your own attribution
+            notices within Derivative Works that You distribute, alongside
+            or as an addendum to the NOTICE text from the Work, provided
+            that such additional attribution notices cannot be construed
+            as modifying the License.
+          </li>
+        </ul>
+        <p>
+          You may add Your own copyright statement to Your modifications and
+          may provide additional or different license terms and conditions
+          for use, reproduction, or distribution of Your modifications, or
+          for any such Derivative Works as a whole, provided Your use,
+          reproduction, and distribution of the Work otherwise complies with
+          the conditions stated in this License.
+        </p>
+        <div class="block">
+          <h2 class="inline">5. Submission of Contributions.</h2>
+          <p class="inline">
+            Unless You explicitly state otherwise,
+            any Contribution intentionally submitted for inclusion in the Work
+            by You to the Licensor shall be under the terms and conditions of
+            this License, without any additional terms or conditions.
+            Notwithstanding the above, nothing herein shall supersede or modify
+            the terms of any separate license agreement you may have executed
+            with Licensor regarding such Contributions.
+          </p>
+        </div>
+        <div class="block">
+          <h2 class="inline">6. Trademarks.</h2>
+          <p class="inline">
+            This License does not grant permission to use the trade
+            names, trademarks, service marks, or product names of the Licensor,
+            except as required for reasonable and customary use in describing the
+            origin of the Work and reproducing the content of the NOTICE file.
+          </p>
+        </div>
+        <div class="block">
+          <h2 class="inline">7. Disclaimer of Warranty.</h2>
+          <p class="inline">
+            Unless required by applicable law or
+            agreed to in writing, Licensor provides the Work (and each
+            Contributor provides its Contributions) on an "AS IS" BASIS,
+            WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+            implied, including, without limitation, any warranties or conditions
+            of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+            PARTICULAR PURPOSE. You are solely responsible for determining the
+            appropriateness of using or redistributing the Work and assume any
+            risks associated with Your exercise of permissions under this License.
+          </p>
+        </div>
+        <div class="block">
+          <h2 class="inline">8. Limitation of Liability.</h2>
+          <p class="inline">
+            In no event and under no legal theory,
+            whether in tort (including negligence), contract, or otherwise,
+            unless required by applicable law (such as deliberate and grossly
+            negligent acts) or agreed to in writing, shall any Contributor be
+            liable to You for damages, including any direct, indirect, special,
+            incidental, or consequential damages of any character arising as a
+            result of this License or out of the use or inability to use the
+            Work (including but not limited to damages for loss of goodwill,
+            work stoppage, computer failure or malfunction, or any and all
+            other commercial damages or losses), even if such Contributor
+            has been advised of the possibility of such damages.
+          </p>
+        </div>
+        <div class="block">
+          <h2 class="inline">9. Accepting Warranty or Additional Liability.</h2>
+          <p class="inline">
+            While redistributing
+            the Work or Derivative Works thereof, You may choose to offer,
+            and charge a fee for, acceptance of support, warranty, indemnity,
+            or other liability obligations and/or rights consistent with this
+            License. However, in accepting such obligations, You may act only
+            on Your own behalf and on Your sole responsibility, not on behalf
+            of any other Contributor, and only if You agree to indemnify,
+            defend, and hold each Contributor harmless for any liability
+            incurred by, or claims asserted against, such Contributor by reason
+            of your accepting any such warranty or additional liability.
+          </p>
+        </div>
+        <p>END OF TERMS AND CONDITIONS</p>
+        <h1>APPENDIX: How to apply the Apache License to your work.</h1>
+        <p>
+          To apply the Apache License to your work, attach the following
+          boilerplate notice, with the fields enclosed by brackets "[]"
+          replaced with your own identifying information. (Don't include
+          the brackets!) The text should be enclosed in the appropriate
+          comment syntax for the file format. We also recommend that a
+          file or class name and description of purpose be included on the
+          same "printed page" as the copyright notice for easier
+          identification within third-party archives.
+        </p>
+        <pre>Copyright [yyyy] [name of copyright owner]&#x000A;&#x000A;Licensed under the Apache License, Version 2.0 (the "License");&#x000A;you may not use this file except in compliance with the License.&#x000A;You may obtain a copy of the License at&#x000A;&#x000A;  http://www.apache.org/licenses/LICENSE-2.0&#x000A;&#x000A;Unless required by applicable law or agreed to in writing, software&#x000A;distributed under the License is distributed on an "AS IS" BASIS,&#x000A;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#x000A;See the License for the specific language governing permissions and&#x000A;limitations under the License.</pre>
+      </div>
+    </div>
+    <div class="library">
+      <!-- https://opensource.org/licenses/Apache-2.0 -->
+      <h1 class="title">kotlin-stdlib</h1>
+      <p class="notice">Copyright &copy; JetBrains Inc. All rights reserved.</p>
+      
+      <div class="license">
+        <h2>
+          Apache License
+          <br/>
+          Version 2.0, January 2004
+          <br/>
+          http://www.apache.org/licenses/
+        </h2>
+        <p>TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION</p>
+        <h2>1. Definitions.</h2>
+        <p>
+          "License" shall mean the terms and conditions for use, reproduction,
+          and distribution as defined by Sections 1 through 9 of this document.
+        </p>
+        <p>
+          "Licensor" shall mean the copyright owner or entity authorized by
+          the copyright owner that is granting the License.
+        </p>
+        <p>
+          "Legal Entity" shall mean the union of the acting entity and all
+          other entities that control, are controlled by, or are under common
+          control with that entity. For the purposes of this definition,
+          "control" means (i) the power, direct or indirect, to cause the
+          direction or management of such entity, whether by contract or
+          otherwise, or (ii) ownership of fifty percent (50%) or more of the
+          outstanding shares, or (iii) beneficial ownership of such entity.
+        </p>
+        <p>
+          "You" (or "Your") shall mean an individual or Legal Entity
+          exercising permissions granted by this License.
+        </p>
+        <p>
+          "Source" form shall mean the preferred form for making modifications,
+          including but not limited to software source code, documentation
+          source, and configuration files.
+        </p>
+        <p>
+          "Object" form shall mean any form resulting from mechanical
+          transformation or translation of a Source form, including but
+          not limited to compiled object code, generated documentation,
+          and conversions to other media types.
+        </p>
+        <p>
+          "Work" shall mean the work of authorship, whether in Source or
+          Object form, made available under the License, as indicated by a
+          copyright notice that is included in or attached to the work
+          (an example is provided in the Appendix below).
+        </p>
+        <p>
+          "Derivative Works" shall mean any work, whether in Source or Object
+          form, that is based on (or derived from) the Work and for which the
+          editorial revisions, annotations, elaborations, or other modifications
+          represent, as a whole, an original work of authorship. For the purposes
+          of this License, Derivative Works shall not include works that remain
+          separable from, or merely link (or bind by name) to the interfaces of,
+          the Work and Derivative Works thereof.
+        </p>
+        <p>
+          "Contribution" shall mean any work of authorship, including
+          the original version of the Work and any modifications or additions
+          to that Work or Derivative Works thereof, that is intentionally
+          submitted to Licensor for inclusion in the Work by the copyright owner
+          or by an individual or Legal Entity authorized to submit on behalf of
+          the copyright owner. For the purposes of this definition, "submitted"
+          means any form of electronic, verbal, or written communication sent
+          to the Licensor or its representatives, including but not limited to
+          communication on electronic mailing lists, source code control systems,
+          and issue tracking systems that are managed by, or on behalf of, the
+          Licensor for the purpose of discussing and improving the Work, but
+          excluding communication that is conspicuously marked or otherwise
+          designated in writing by the copyright owner as "Not a Contribution."
+        </p>
+        <p>
+          "Contributor" shall mean Licensor and any individual or Legal Entity
+          on behalf of whom a Contribution has been received by Licensor and
+          subsequently incorporated within the Work.
+        </p>
+        <div class="block">
+          <h2 class="inline">2. Grant of Copyright License.</h2>
+          <p class="inline">
+            Subject to the terms and conditions of
+            this License, each Contributor hereby grants to You a perpetual,
+            worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+            copyright license to reproduce, prepare Derivative Works of,
+            publicly display, publicly perform, sublicense, and distribute the
+            Work and such Derivative Works in Source or Object form.
+          </p>
+        </div>
+        <div class="block">
+          <h2 class="inline">3. Grant of Patent License.</h2>
+          <p class="inline">
+            Subject to the terms and conditions of
+            this License, each Contributor hereby grants to You a perpetual,
+            worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+            (except as stated in this section) patent license to make, have made,
+            use, offer to sell, sell, import, and otherwise transfer the Work,
+            where such license applies only to those patent claims licensable
+            by such Contributor that are necessarily infringed by their
+            Contribution(s) alone or by combination of their Contribution(s)
+            with the Work to which such Contribution(s) was submitted. If You
+            institute patent litigation against any entity (including a
+            cross-claim or counterclaim in a lawsuit) alleging that the Work
+            or a Contribution incorporated within the Work constitutes direct
+            or contributory patent infringement, then any patent licenses
+            granted to You under this License for that Work shall terminate
+            as of the date such litigation is filed.
+          </p>
+        </div>
+        <div class="block">
+          <h2 class="inline">4. Redistribution.</h2>
+          <p class="inline">
+            You may reproduce and distribute copies of the
+            Work or Derivative Works thereof in any medium, with or without
+            modifications, and in Source or Object form, provided that You
+            meet the following conditions:
+          </p>
+        </div>
+        <ul class="low-alpha">
+          <li>
+            You must give any other recipients of the Work or
+            Derivative Works a copy of this License; and
+          </li>
+          <li>
+            You must cause any modified files to carry prominent notices
+            stating that You changed the files; and
+          </li>
+          <li>
+            You must retain, in the Source form of any Derivative Works
+            that You distribute, all copyright, patent, trademark, and
+            attribution notices from the Source form of the Work,
+            excluding those notices that do not pertain to any part of |
+            the Derivative Works; and
+          </li>
+          <li>
+            If the Work includes a "NOTICE" text file as part of its
+            distribution, then any Derivative Works that You distribute must
+            include a readable copy of the attribution notices contained
+            within such NOTICE file, excluding those notices that do not
+            pertain to any part of the Derivative Works, in at least one
+            of the following places: within a NOTICE text file distributed
+            as part of the Derivative Works; within the Source form or
+            documentation, if provided along with the Derivative Works; or,
+            within a display generated by the Derivative Works, if and
+            wherever such third-party notices normally appear. The contents
+            of the NOTICE file are for informational purposes only and
+            do not modify the License. You may add Your own attribution
+            notices within Derivative Works that You distribute, alongside
+            or as an addendum to the NOTICE text from the Work, provided
+            that such additional attribution notices cannot be construed
+            as modifying the License.
+          </li>
+        </ul>
+        <p>
+          You may add Your own copyright statement to Your modifications and
+          may provide additional or different license terms and conditions
+          for use, reproduction, or distribution of Your modifications, or
+          for any such Derivative Works as a whole, provided Your use,
+          reproduction, and distribution of the Work otherwise complies with
+          the conditions stated in this License.
+        </p>
+        <div class="block">
+          <h2 class="inline">5. Submission of Contributions.</h2>
+          <p class="inline">
+            Unless You explicitly state otherwise,
+            any Contribution intentionally submitted for inclusion in the Work
+            by You to the Licensor shall be under the terms and conditions of
+            this License, without any additional terms or conditions.
+            Notwithstanding the above, nothing herein shall supersede or modify
+            the terms of any separate license agreement you may have executed
+            with Licensor regarding such Contributions.
+          </p>
+        </div>
+        <div class="block">
+          <h2 class="inline">6. Trademarks.</h2>
+          <p class="inline">
+            This License does not grant permission to use the trade
+            names, trademarks, service marks, or product names of the Licensor,
+            except as required for reasonable and customary use in describing the
+            origin of the Work and reproducing the content of the NOTICE file.
+          </p>
+        </div>
+        <div class="block">
+          <h2 class="inline">7. Disclaimer of Warranty.</h2>
+          <p class="inline">
+            Unless required by applicable law or
+            agreed to in writing, Licensor provides the Work (and each
+            Contributor provides its Contributions) on an "AS IS" BASIS,
+            WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+            implied, including, without limitation, any warranties or conditions
+            of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+            PARTICULAR PURPOSE. You are solely responsible for determining the
+            appropriateness of using or redistributing the Work and assume any
+            risks associated with Your exercise of permissions under this License.
+          </p>
+        </div>
+        <div class="block">
+          <h2 class="inline">8. Limitation of Liability.</h2>
+          <p class="inline">
+            In no event and under no legal theory,
+            whether in tort (including negligence), contract, or otherwise,
+            unless required by applicable law (such as deliberate and grossly
+            negligent acts) or agreed to in writing, shall any Contributor be
+            liable to You for damages, including any direct, indirect, special,
+            incidental, or consequential damages of any character arising as a
+            result of this License or out of the use or inability to use the
+            Work (including but not limited to damages for loss of goodwill,
+            work stoppage, computer failure or malfunction, or any and all
+            other commercial damages or losses), even if such Contributor
+            has been advised of the possibility of such damages.
+          </p>
+        </div>
+        <div class="block">
+          <h2 class="inline">9. Accepting Warranty or Additional Liability.</h2>
+          <p class="inline">
+            While redistributing
+            the Work or Derivative Works thereof, You may choose to offer,
+            and charge a fee for, acceptance of support, warranty, indemnity,
+            or other liability obligations and/or rights consistent with this
+            License. However, in accepting such obligations, You may act only
+            on Your own behalf and on Your sole responsibility, not on behalf
+            of any other Contributor, and only if You agree to indemnify,
+            defend, and hold each Contributor harmless for any liability
+            incurred by, or claims asserted against, such Contributor by reason
+            of your accepting any such warranty or additional liability.
+          </p>
+        </div>
+        <p>END OF TERMS AND CONDITIONS</p>
+        <h1>APPENDIX: How to apply the Apache License to your work.</h1>
+        <p>
+          To apply the Apache License to your work, attach the following
+          boilerplate notice, with the fields enclosed by brackets "[]"
+          replaced with your own identifying information. (Don't include
+          the brackets!) The text should be enclosed in the appropriate
+          comment syntax for the file format. We also recommend that a
+          file or class name and description of purpose be included on the
+          same "printed page" as the copyright notice for easier
+          identification within third-party archives.
+        </p>
+        <pre>Copyright [yyyy] [name of copyright owner]&#x000A;&#x000A;Licensed under the Apache License, Version 2.0 (the "License");&#x000A;you may not use this file except in compliance with the License.&#x000A;You may obtain a copy of the License at&#x000A;&#x000A;  http://www.apache.org/licenses/LICENSE-2.0&#x000A;&#x000A;Unless required by applicable law or agreed to in writing, software&#x000A;distributed under the License is distributed on an "AS IS" BASIS,&#x000A;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#x000A;See the License for the specific language governing permissions and&#x000A;limitations under the License.</pre>
+      </div>
+    </div>
+    <div class="library">
+      <!-- https://opensource.org/licenses/Apache-2.0 -->
       <h1 class="title">TwoWayView Library</h1>
       <p class="notice">Copyright &copy; Lucas Rocha. All rights reserved.</p>
       <p><a href="https://github.com/lucasr/twoway-view">https://github.com/lucasr/twoway-view</a></p>

--- a/circle.yml
+++ b/circle.yml
@@ -20,8 +20,10 @@ dependencies:
 
 test:
   override:
-    - ./gradlew clean assembleProductionDebug check jacocoTestReportDevelop
-    - find . -name app*debug.apk -exec cp {} $CIRCLE_ARTIFACTS/ \;
+    - TERM=dumb ./gradlew assembleProductionDebug
+    - TERM=dumb ./gradlew check
+    - TERM=dumb ./gradlew jacocoTestReportDevelop
+    - find . -name app*debug.apk -exec mv {} $CIRCLE_ARTIFACTS/ \;
 
 deployment:
   production:

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ build_tools_version=25.0.2
 min_sdk_version=16
 target_sdk_version=25
 # Library versions
+kotlin_version=1.0.6
 support_lib_version=25.1.1
 # Build options
 org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8


### PR DESCRIPTION
## Overview (Required)
- use kapt, kotlin codes can reference classes generated by DataBinding, Orma, KVS-Schema

## why not use `kotlin-kapt`
[kotlin-kapt](https://blog.jetbrains.com/kotlin/2016/09/kotlin-1-0-4-is-here/) is unstable yet.
