### PR TITLE
save APK into CircleCI's artifact

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,6 +21,7 @@ dependencies:
 test:
   override:
     - ./gradlew clean assembleProductionDebug check jacocoTestReportDevelop
+    - find . -name app*debug.apk -exec mv {} $CIRCLE_ARTIFACTS/ \;
 
 deployment:
   production:


### PR DESCRIPTION
## Issue
-

## Overview (Required)

By saving the APK in Circle CI's artifact, we can download and try it easily just with a mobile phone (without PC for build), just by browsing the file like below:

![slice](https://cloud.githubusercontent.com/assets/11763113/22674106/6899eb02-ed21-11e6-8ea6-bfcc1348ff8f.png)

With this feature, we can try the APK even during commute in the train :)
It would be helpful for some people in reviewing and discussing the Pull Requests.

## Links
-

## Screenshot

Nothing changed.