### PR TITLE
Applied a workaround to fix wrong layout when running on api 16

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/util/ViewUtil.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/util/ViewUtil.java
@@ -1,0 +1,34 @@
+package io.github.droidkaigi.confsched2017.util;
+
+import android.support.annotation.NonNull;
+import android.view.View;
+import android.view.ViewTreeObserver;
+
+public class ViewUtil {
+    private static final String TAG = ViewUtil.class.getSimpleName();
+
+    /**
+     * @see ViewTreeObserver
+     */
+    public interface OnGlobalLayoutListener {
+
+        /**
+         * This emulates {@link ViewTreeObserver.OnGlobalLayoutListener#onGlobalLayout()}
+         *
+         * @return if true this listener should be removed, otherwise false.
+         * @see android.view.ViewTreeObserver.OnGlobalLayoutListener
+         */
+        boolean onGlobalLayout();
+    }
+
+    public static void addOneTimeOnGlobalLayoutListener(@NonNull View view, @NonNull OnGlobalLayoutListener onGlobalLayoutListener) {
+        view.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
+            @Override
+            public void onGlobalLayout() {
+                if (onGlobalLayoutListener.onGlobalLayout()) {
+                    view.getViewTreeObserver().removeOnGlobalLayoutListener(this);
+                }
+            }
+        });
+    }
+}

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SessionsFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SessionsFragment.java
@@ -22,6 +22,7 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewConfiguration;
 import android.view.ViewGroup;
+import android.view.ViewTreeObserver;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
@@ -36,6 +37,7 @@ import io.github.droidkaigi.confsched2017.databinding.FragmentSessionsBinding;
 import io.github.droidkaigi.confsched2017.databinding.ViewSessionCellBinding;
 import io.github.droidkaigi.confsched2017.model.Room;
 import io.github.droidkaigi.confsched2017.model.Session;
+import io.github.droidkaigi.confsched2017.util.ViewUtil;
 import io.github.droidkaigi.confsched2017.view.activity.SearchActivity;
 import io.github.droidkaigi.confsched2017.view.activity.SessionDetailActivity;
 import io.github.droidkaigi.confsched2017.view.customview.ArrayRecyclerAdapter;
@@ -166,6 +168,17 @@ public class SessionsFragment extends BaseFragment implements SessionViewModel.C
 
             return false;
         });
+
+        ViewUtil.addOneTimeOnGlobalLayoutListener(binding.headerRow, () -> {
+            if (binding.headerRow.getHeight() > 0) {
+                binding.recyclerView.getLayoutParams().height = binding.root.getHeight() - binding.border.getHeight() - binding.headerRow.getHeight();
+                binding.recyclerView.requestLayout();
+                return true;
+            } else {
+                return false;
+            }
+        });
+
         binding.recyclerView.clearOnScrollListeners();
         binding.recyclerView.addOnScrollListener(new RecyclerView.OnScrollListener() {
             @Override

--- a/app/src/main/res/layout/fragment_sessions.xml
+++ b/app/src/main/res/layout/fragment_sessions.xml
@@ -23,19 +23,16 @@
                 android:layout_height="match_parent"
                 >
 
-            <RelativeLayout
+            <LinearLayout
                     android:layout_width="wrap_content"
                     android:layout_height="match_parent"
+                    android:orientation="vertical"
                     >
 
                 <LinearLayout
                         android:id="@+id/header_row"
                         android:layout_width="match_parent"
                         android:layout_height="@dimen/session_table_header_row_height"
-                        android:layout_alignEnd="@+id/recycler_view"
-                        android:layout_alignLeft="@+id/recycler_view"
-                        android:layout_alignRight="@+id/recycler_view"
-                        android:layout_alignStart="@+id/recycler_view"
                         android:background="@color/white"
                         android:divider="@drawable/divider"
                         android:orientation="horizontal"
@@ -45,27 +42,21 @@
                 <View
                         android:id="@+id/border"
                         style="@style/Border"
-                        android:layout_alignEnd="@+id/recycler_view"
-                        android:layout_alignLeft="@+id/recycler_view"
-                        android:layout_alignRight="@+id/recycler_view"
-                        android:layout_alignStart="@+id/recycler_view"
-                        android:layout_below="@id/header_row"
                         android:background="@color/grey300"
                         />
 
                 <io.github.droidkaigi.confsched2017.view.customview.TouchlessTwoWayView
-                        android:id="@+id/recycler_view"
-                        android:layout_width="wrap_content"
-                        android:layout_height="match_parent"
-                        android:layout_below="@id/border"
-                        android:orientation="vertical"
-                        android:scrollbars="vertical"
-                        app:twowayview_layoutManager="org.lucasr.twowayview.widget.SpannableGridLayoutManager"
-                        app:twowayview_numColumns="6"
-                        app:twowayview_numRows="3"
-                        />
+                    android:id="@+id/recycler_view"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:orientation="vertical"
+                    android:scrollbars="vertical"
+                    app:twowayview_layoutManager="org.lucasr.twowayview.widget.SpannableGridLayoutManager"
+                    app:twowayview_numColumns="6"
+                    app:twowayview_numRows="3"
+                    />
 
-            </RelativeLayout>
+            </LinearLayout>
 
         </HorizontalScrollView>
 


### PR DESCRIPTION
## Issue
- https://github.com/DroidKaigi/conference-app-2017/issues/128

## Overview (Required)
- It seems twoway-view cannot recognize recycle-span correctly.
- I fixed RecyclerView's height with modifying layout definitions, and then confirmed this can be applied as a workaround of this problem.

## Links
- None

## Screenshot
 Before | After
:--: | :--:
<img src="https://cloud.githubusercontent.com/assets/1386930/22655776/902308e0-ecd4-11e6-8f4f-5a5fb82eb3bd.gif" width="300" /> | ![api16](https://cloud.githubusercontent.com/assets/4340693/22674582/06e04a20-ed24-11e6-8410-9574877b5738.gif)

Just in case, for API 23
![bullheadmmb29qjmatsu02072017030504](https://cloud.githubusercontent.com/assets/4340693/22659916/e56707a8-ece2-11e6-939d-ccd29a915288.gif)
