### PR TITLE
Update Retrolambda 3.4.0 -> 3.5.0 and remove retrolambdaConfig

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -199,7 +199,6 @@ dependencies {
     compile 'io.reactivex.rxjava2:rxjava:2.0.2'
     compile 'io.reactivex.rxjava2:rxandroid:2.0.1'
     compile 'com.annimon:stream:1.1.4'
-    retrolambdaConfig 'net.orfjackal.retrolambda:retrolambda:2.3.0'
     compile 'uk.co.chrisjenx:calligraphy:2.2.0'
 
     // Android Utility

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'com.google.gms:google-services:3.0.0'
-        classpath 'me.tatarka:gradle-retrolambda:3.4.0'
+        classpath 'me.tatarka:gradle-retrolambda:3.5.0'
         classpath 'me.tatarka.retrolambda.projectlombok:lombok.ast:0.2.3.a2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.0.6"
         classpath 'com.cookpad.android.licensetools:license-tools-plugin:0.19.1'


### PR DESCRIPTION
## Overview (Required)
I have updated gradle-retrolambda 3.4.0 -> 3.5.0. This allows us to remove `retrolambdaConfig` setting as the default retrolambda version of gradle-retrolambda 3.5.0 is `2.5.0`.

## Links
- gradle-retrolambda changelog: https://github.com/evant/gradle-retrolambda/blob/master/CHANGELOG.md#350
- retrolambda changelog: https://github.com/orfjackal/retrolambda#retrolambda-250-2017-01-22
