### PR TITLE
Add  ./gradlew dependencyUpdates

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'me.tatarka.retrolambda'
 apply plugin: 'kotlin-android'
 apply plugin: 'com.cookpad.android.licensetools'
+apply plugin: 'com.github.ben-manes.versions'
 
 // Manifest version
 def versionMajor = 0
@@ -297,6 +298,20 @@ task jacocoTestReportDevelop(type: JacocoReport, dependsOn: ['testDevelopDebugUn
 }
 
 tasks['check'].dependsOn checkLicenses
+
+// report only stable versions
+dependencyUpdates.resolutionStrategy = {
+    componentSelection { rules ->
+        rules.all { ComponentSelection selection ->
+            boolean rejected = ['alpha', 'beta', 'rc', 'cr', 'm'].any { qualifier ->
+                selection.candidate.version ==~ /(?i).*[.-]${qualifier}[.\d-]*/
+            }
+            if (rejected) {
+                selection.reject('Release candidate')
+            }
+        }
+    }
+}
 
 // MUST BE AT THE BOTTOM
 apply plugin: 'com.google.gms.google-services'

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ buildscript {
         classpath 'me.tatarka.retrolambda.projectlombok:lombok.ast:0.2.3.a2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.0.6"
         classpath 'com.cookpad.android.licensetools:license-tools-plugin:0.19.1'
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.13.0'
     }
 
     configurations.classpath.exclude group: 'com.android.tools.external.lombok'


### PR DESCRIPTION
## Issue
- None

## Overview (Required)
- ./gradlew dependencyUpdates → /app/build/dependencyUpdates/report.txt

## Links
- https://github.com/ben-manes/gradle-versions-plugin

## report.txt

:app Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies are using the latest milestone version:
 - com.android.support:animated-vector-drawable:25.1.1
 - com.android.support:appcompat-v7:25.1.1
 - com.squareup.assertj:assertj-android:1.1.1
 - com.android.databinding:baseLibrary:2.2.3
 - uk.co.chrisjenx:calligraphy:2.2.0
 - com.android.databinding:compiler:2.2.3
 - com.squareup.retrofit2:converter-gson:2.1.0
 - com.android.support:customtabs:25.1.1
 - com.android.support:design:25.1.1
 - com.android.support.test.espresso:espresso-core:2.2.2
 - com.android.support.test.espresso:espresso-intents:2.2.2
 - com.google.firebase:firebase-core:10.0.1
 - com.google.firebase:firebase-crash:10.0.1
 - junit:junit:4.12
 - com.github.sys1yagi:kmockito:0.1.2
 - org.jetbrains.kotlin:kotlin-annotation-processing:1.0.6
 - org.jetbrains.kotlin:kotlin-stdlib:1.0.6
 - org.jetbrains.kotlin:kotlin-test-junit:1.0.6
 - com.rejasupotaro:kvs-schema:5.0.1
 - com.rejasupotaro:kvs-schema-compiler:5.0.1
 - com.squareup.leakcanary:leakcanary-android:1.5
 - com.squareup.leakcanary:leakcanary-android-no-op:1.5
 - net.opacapp:multiline-collapsingtoolbar:1.3.1
 - com.squareup.picasso:picasso:2.5.2
 - com.android.support:recyclerview-v7:25.1.1
 - com.squareup.retrofit2:retrofit:2.1.0
 - com.jakewharton.retrofit:retrofit2-rxjava2-adapter:1.0.0
 - org.robolectric:robolectric:3.2.2
 - com.android.support.test:rules:0.5
 - com.android.support.test:runner:0.5
 - io.reactivex.rxjava2:rxandroid:2.0.1
 - com.facebook.stetho:stetho:1.4.2
 - com.facebook.stetho:stetho-okhttp3:1.4.2
 - com.facebook.stetho:stetho-timber:1.4.2
 - com.android.support:support-annotations:25.1.1
 - com.android.support:support-v4:25.1.1
 - com.android.support:support-vector-drawable:25.1.1
 - com.jakewharton.timber:timber:4.5.1

The following dependencies have later milestone versions:
 - com.android.databinding:adapters [1.2.1 -> 1.3.1]
 - com.google.dagger:dagger [2.7 -> 2.9]
 - com.google.dagger:dagger-compiler [2.7 -> 2.9]
 - com.google.android:flexbox [0.2.3 -> 0.2.5]
 - com.google.code.gson:gson [2.7 -> 2.8.0]
 - javax.annotation:jsr250-api [1.0 -> 1.0-20050927.133100]
 - com.android.databinding:library [1.2.1 -> 1.3.1]
 - org.mockito:mockito-android [2.7.0 -> 2.7.4]
 - org.mockito:mockito-core [2.7.0 -> 2.7.4]
 - com.squareup.okhttp3:okhttp [3.4.1 -> 3.6.0]
 - com.github.gfx.android.orma:orma [4.1.0 -> 4.1.1]
 - com.github.gfx.android.orma:orma-processor [4.1.0 -> 4.1.1]
 - io.reactivex.rxjava2:rxjava [2.0.2 -> 2.0.5]
 - com.annimon:stream [1.1.4 -> 1.1.5]

Failed to determine the latest version for the following dependencies (use --info for details):
 - org.lucasr.twowayview:core
 - com.taroid.knit:knit
 - org.lucasr.twowayview:layouts
