### PR TITLE
sessionId is never used in NotificationReceiver

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/receiver/NotificationReceiver.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/receiver/NotificationReceiver.java
@@ -18,15 +18,13 @@ public class NotificationReceiver extends BroadcastReceiver {
 
     private static final String TAG = NotificationReceiver.class.getSimpleName();
 
-    private static final String KEY_SESSION_ID = "session_id";
     private static final String KEY_TITLE = "title";
     private static final String KEY_TEXT = "text";
 
     private static final int NOTIFICATION_ID = 1;
 
-    public static Intent createIntent(Context context, int sessionId, String title, String text) {
+    public static Intent createIntent(Context context, String title, String text) {
         Intent intent = new Intent(context, NotificationReceiver.class);
-        intent.putExtra(NotificationReceiver.KEY_SESSION_ID, sessionId);
         intent.putExtra(NotificationReceiver.KEY_TITLE, title);
         intent.putExtra(NotificationReceiver.KEY_TEXT, text);
         return intent;
@@ -39,7 +37,6 @@ public class NotificationReceiver extends BroadcastReceiver {
             Timber.tag(TAG).v("Notification is disabled.");
             return;
         }
-        int sessionId = intent.getIntExtra(KEY_SESSION_ID, 0);
         String title = intent.getStringExtra(KEY_TITLE);
         String text = intent.getStringExtra(KEY_TEXT);
         int priority = prefs.getHeadsUpFlag() ? NotificationCompat.PRIORITY_HIGH : NotificationCompat.PRIORITY_DEFAULT;

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/util/AlarmUtil.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/util/AlarmUtil.java
@@ -46,7 +46,7 @@ public class AlarmUtil {
                 DateUtil.getHourMinute(displaySTime),
                 DateUtil.getHourMinute(displayETime),
                 room);
-        Intent intent = NotificationReceiver.createIntent(context, session.id, title, text);
+        Intent intent = NotificationReceiver.createIntent(context, title, text);
         return PendingIntent.getBroadcast(context, REQ_CODE_NOTIFICATION,
                 intent, PendingIntent.FLAG_UPDATE_CURRENT);
     }


### PR DESCRIPTION
## Issue
none

## Overview (Required)
I found that sessionId is never used in NotificationReceiver.
So, I delete that.

## Links
none

## Screenshot
none
