### PR TITLE
Add open link when contoributors item

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/ContributorsFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/ContributorsFragment.java
@@ -1,10 +1,13 @@
 package io.github.droidkaigi.confsched2017.view.fragment;
 
 import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.widget.GridLayoutManager;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -95,8 +98,14 @@ public class ContributorsFragment extends BaseFragment implements ContributorsVi
 
     @Override
     public void onClickContributor(String htmlUrl) {
-        // TODO implement here
-        Timber.d("htmlUrl: %s", htmlUrl);
+        Timber.i("contributor htmlUrl: %s", htmlUrl);
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(htmlUrl));
+
+        if (intent.resolveActivity(getContext().getPackageManager()) == null) {
+            return;
+        }
+
+        startActivity(intent);
     }
 
     private static class Adapter


### PR DESCRIPTION
## Issue
none

## Overview (Required)
There is no action even if you click on Contributor item.
So we decided to open the url passed in the browser.

## Links
- https://github.com/DroidKaigi/conference-app-2017/issues/78
- https://github.com/DroidKaigi/conference-app-2017/pull/138

## Screenshot
none
