### PR TITLE
Remove unnecessary thread control.

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/repository/sessions/SessionsLocalDataSource.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/repository/sessions/SessionsLocalDataSource.java
@@ -98,7 +98,6 @@ public final class SessionsLocalDataSource implements SessionsDataSource {
     public void updateAllAsync(List<Session> sessions) {
         orma.transactionAsCompletable(() -> updateAllSync(sessions))
                 .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
                 .subscribe();
     }
 


### PR DESCRIPTION
## Issue

None

## Overview (Required)

Remove unnecessary thread control.
Since updateAllAsync() in SessionsLocalDataSource has no subscriber, I think that obserbeOn() is unnecessary.

## Links

None

## Screenshot

None
