### PR TITLE
Change launch activity on notification tap

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,6 +36,7 @@
                 android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation"
                 android:exported="false"
                 android:label="@string/session_detail"
+                android:parentActivityName=".view.activity.MainActivity"
                 android:theme="@style/AppTheme.NoActionBar"
                 />
 

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/receiver/NotificationReceiver.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/receiver/NotificationReceiver.java
@@ -5,7 +5,6 @@ import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.support.annotation.Nullable;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationManagerCompat;
 import android.support.v4.content.ContextCompat;
@@ -27,22 +26,12 @@ public class NotificationReceiver extends BroadcastReceiver {
 
     private static final int NOTIFICATION_ID = 1;
 
-    private static final String ACTION_FROM_NOTIFICATION = TAG + "_from_notification";
-
     public static Intent createIntent(Context context, int sessionId, String title, String text) {
         Intent intent = new Intent(context, NotificationReceiver.class);
         intent.putExtra(NotificationReceiver.KEY_SESSION_ID, sessionId);
         intent.putExtra(NotificationReceiver.KEY_TITLE, title);
         intent.putExtra(NotificationReceiver.KEY_TEXT, text);
         return intent;
-    }
-
-    public static boolean checkLaunchFromNotification(@Nullable Intent intent) {
-        if (intent == null) {
-            return false;
-        }
-        String action = intent.getAction();
-        return action != null && action.equals(NotificationReceiver.ACTION_FROM_NOTIFICATION);
     }
 
     @Override
@@ -58,7 +47,6 @@ public class NotificationReceiver extends BroadcastReceiver {
         int priority = prefs.getHeadsUpFlag() ? NotificationCompat.PRIORITY_HIGH : NotificationCompat.PRIORITY_DEFAULT;
         Intent openIntent = SessionDetailActivity.createIntent(context, sessionId);
         openIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
-        openIntent.setAction(ACTION_FROM_NOTIFICATION);
         PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, openIntent, 0);
         Notification notification = new NotificationCompat.Builder(context)
                 .setTicker(title)

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/receiver/NotificationReceiver.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/receiver/NotificationReceiver.java
@@ -5,13 +5,14 @@ import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.support.annotation.Nullable;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationManagerCompat;
 import android.support.v4.content.ContextCompat;
 
 import io.github.droidkaigi.confsched2017.R;
 import io.github.droidkaigi.confsched2017.pref.DefaultPrefs;
-import io.github.droidkaigi.confsched2017.view.activity.MainActivity;
+import io.github.droidkaigi.confsched2017.view.activity.SessionDetailActivity;
 import timber.log.Timber;
 
 public class NotificationReceiver extends BroadcastReceiver {
@@ -19,10 +20,14 @@ public class NotificationReceiver extends BroadcastReceiver {
     private static final String TAG = NotificationReceiver.class.getSimpleName();
 
     private static final String KEY_SESSION_ID = "session_id";
+
     private static final String KEY_TITLE = "title";
+
     private static final String KEY_TEXT = "text";
 
     private static final int NOTIFICATION_ID = 1;
+
+    private static final String ACTION_FROM_NOTIFICATION = TAG + "_from_notification";
 
     public static Intent createIntent(Context context, int sessionId, String title, String text) {
         Intent intent = new Intent(context, NotificationReceiver.class);
@@ -30,6 +35,14 @@ public class NotificationReceiver extends BroadcastReceiver {
         intent.putExtra(NotificationReceiver.KEY_TITLE, title);
         intent.putExtra(NotificationReceiver.KEY_TEXT, text);
         return intent;
+    }
+
+    public static boolean checkLaunchFromNotification(@Nullable Intent intent) {
+        if (intent == null) {
+            return false;
+        }
+        String action = intent.getAction();
+        return action != null && action.equals(NotificationReceiver.ACTION_FROM_NOTIFICATION);
     }
 
     @Override
@@ -43,8 +56,9 @@ public class NotificationReceiver extends BroadcastReceiver {
         String title = intent.getStringExtra(KEY_TITLE);
         String text = intent.getStringExtra(KEY_TEXT);
         int priority = prefs.getHeadsUpFlag() ? NotificationCompat.PRIORITY_HIGH : NotificationCompat.PRIORITY_DEFAULT;
-        Intent openIntent = new Intent(context, MainActivity.class);
+        Intent openIntent = SessionDetailActivity.createIntent(context, sessionId);
         openIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
+        openIntent.setAction(ACTION_FROM_NOTIFICATION);
         PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, openIntent, 0);
         Notification notification = new NotificationCompat.Builder(context)
                 .setTicker(title)

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/SessionDetailActivity.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/SessionDetailActivity.java
@@ -5,8 +5,12 @@ import android.content.Intent;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.v4.app.NavUtils;
+import android.support.v4.app.TaskStackBuilder;
+import android.view.MenuItem;
 
 import io.github.droidkaigi.confsched2017.R;
+import io.github.droidkaigi.confsched2017.receiver.NotificationReceiver;
 import io.github.droidkaigi.confsched2017.view.fragment.SessionDetailFragment;
 
 public class SessionDetailActivity extends BaseActivity {
@@ -27,6 +31,21 @@ public class SessionDetailActivity extends BaseActivity {
 
         final int sessionId = getIntent().getIntExtra(EXTRA_SESSION_ID, 0);
         replaceFragment(SessionDetailFragment.newInstance(sessionId), R.id.content_view);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                if (NotificationReceiver.checkLaunchFromNotification(getIntent())) {
+                    Intent upIntent = NavUtils.getParentActivityIntent(this);
+                    TaskStackBuilder.create(this)
+                            .addNextIntentWithParentStack(upIntent)
+                            .startActivities();
+                    return true;
+                }
+        }
+        return super.onOptionsItemSelected(item);
     }
 
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/SessionDetailActivity.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/SessionDetailActivity.java
@@ -5,12 +5,9 @@ import android.content.Intent;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.v4.app.NavUtils;
-import android.support.v4.app.TaskStackBuilder;
 import android.view.MenuItem;
 
 import io.github.droidkaigi.confsched2017.R;
-import io.github.droidkaigi.confsched2017.receiver.NotificationReceiver;
 import io.github.droidkaigi.confsched2017.view.fragment.SessionDetailFragment;
 
 public class SessionDetailActivity extends BaseActivity {
@@ -37,15 +34,17 @@ public class SessionDetailActivity extends BaseActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case android.R.id.home:
-                if (NotificationReceiver.checkLaunchFromNotification(getIntent())) {
-                    Intent upIntent = NavUtils.getParentActivityIntent(this);
-                    TaskStackBuilder.create(this)
-                            .addNextIntentWithParentStack(upIntent)
-                            .startActivities();
-                    return true;
-                }
+                upToMainActivity();
+                return true;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    private void upToMainActivity() {
+        Intent upIntent = new Intent(getApplicationContext(), MainActivity.class);
+        upIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        startActivity(upIntent);
+        finish();
     }
 
 }


### PR DESCRIPTION
## Issue
- #151 

## Overview (Required)
- Change the launch activity on notification tap from `MainActivity` to `SessionDetailActivity`.
- `SessionDetailActivity` always navigates to `MainActivity` when "up button" is clicked.

## Links
- [Providing Up Navigation | Android Developers](https://developer.android.com/training/implementing-navigation/ancestral.html)

## Note
By the above Android Developers guideline, we should use `NavUtils#shouldUpRecreateTask` to check if `MainActivity` has been added to backstack, however the method always returns false as far as I worked.
So I now use custom action of `Intent` to check it.
Please tell me a good way for handling "up button" click event if you know.

Thanks.