### PR TITLE
Fix layout preview of fragment_settings.xml on Android Studio

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/customview/SettingSwitchRowView.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/customview/SettingSwitchRowView.java
@@ -30,9 +30,9 @@ public class SettingSwitchRowView extends RelativeLayout {
 
     public SettingSwitchRowView(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
-        binding = DataBindingUtil.inflate(LayoutInflater.from(context), R.layout.view_setting_switch_row, this, true);
 
         if (!isInEditMode()) {
+            binding = DataBindingUtil.inflate(LayoutInflater.from(context), R.layout.view_setting_switch_row, this, true);
             TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.SettingSwitchRow);
 
             String title = a.getString(R.styleable.SettingSwitchRow_settingTitle);
@@ -49,6 +49,8 @@ public class SettingSwitchRowView extends RelativeLayout {
             });
 
             a.recycle();
+        } else {
+            LayoutInflater.from(context).inflate(R.layout.view_setting_switch_row, this, true);
         }
     }
 

--- a/app/src/main/res/layout/view_setting_switch_row.xml
+++ b/app/src/main/res/layout/view_setting_switch_row.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        >
 
     <RelativeLayout
             android:layout_width="match_parent"
@@ -17,7 +19,7 @@
                 android:layout_toStartOf="@+id/setting_switch"
                 android:ellipsize="end"
                 android:lines="1"
-                android:text="@string/settings_notification"
+                tools:text="Setting title"
                 />
 
         <TextView
@@ -29,6 +31,7 @@
                 android:layout_marginTop="@dimen/space_8dp"
                 android:layout_toLeftOf="@+id/setting_switch"
                 android:layout_toStartOf="@+id/setting_switch"
+                tools:text="here comes descriptions what this option is."
                 />
 
         <android.support.v7.widget.SwitchCompat


### PR DESCRIPTION
## Issue
-`fragment_settings.xml`'s layout preview was not drawn correctly causes constructor of `SettingsSwitchRowView`.

## Overview (Required)
-

## Links
-

## Screenshot
Before | After
:--: | :--:
<img width="490" alt="before" src="https://cloud.githubusercontent.com/assets/7608725/22688070/fc6476c6-ed6d-11e6-83a9-8b6759c3b3cd.png"> | <img width="502" alt="after" src="https://cloud.githubusercontent.com/assets/7608725/22688074/015bd7b4-ed6e-11e6-9d00-22ec553e1389.png">
