### PR TITLE
Group notification

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/receiver/NotificationReceiver.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/receiver/NotificationReceiver.java
@@ -24,6 +24,9 @@ public class NotificationReceiver extends BroadcastReceiver {
 
     private static final String KEY_TEXT = "text";
 
+    private static final String GROUP_NAME = "droidkaigi";
+    private static final int GROUP_NOTIFICATION_ID = 0;
+
     public static Intent createIntent(Context context, int sessionId, String title, String text) {
         Intent intent = new Intent(context, NotificationReceiver.class);
         intent.putExtra(NotificationReceiver.KEY_SESSION_ID, sessionId);
@@ -39,10 +42,36 @@ public class NotificationReceiver extends BroadcastReceiver {
             Timber.tag(TAG).v("Notification is disabled.");
             return;
         }
+
+        showGroupNotification(context);
+
+        showChildNotification(context, intent, prefs.getHeadsUpFlag());
+    }
+
+    /**
+     * Show group notification
+     * @param context Context
+     */
+    private void showGroupNotification(Context context) {
+        Notification groupNotification = new NotificationCompat.Builder(context)
+                .setSmallIcon(R.mipmap.ic_launcher)
+                .setColor(ContextCompat.getColor(context, R.color.theme))
+                .setGroup(GROUP_NAME)
+                .setGroupSummary(true)
+                .build();
+        NotificationManagerCompat.from(context).notify(GROUP_NOTIFICATION_ID, groupNotification);
+    }
+
+    /**
+     * Show child notification
+     * @param context Context
+     * @param intent Intent
+     */
+    private void showChildNotification(Context context, Intent intent, boolean headsUp) {
         int sessionId = intent.getIntExtra(KEY_SESSION_ID, 0);
         String title = intent.getStringExtra(KEY_TITLE);
         String text = intent.getStringExtra(KEY_TEXT);
-        int priority = prefs.getHeadsUpFlag() ? NotificationCompat.PRIORITY_HIGH : NotificationCompat.PRIORITY_DEFAULT;
+        int priority = headsUp ? NotificationCompat.PRIORITY_HIGH : NotificationCompat.PRIORITY_DEFAULT;
         Intent openIntent = SessionDetailActivity.createIntent(context, sessionId);
         openIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
         PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, openIntent, 0);
@@ -56,6 +85,7 @@ public class NotificationReceiver extends BroadcastReceiver {
                 .setContentIntent(pendingIntent)
                 .setDefaults(NotificationCompat.DEFAULT_ALL)
                 .setPriority(priority)
+                .setGroup(GROUP_NAME)
                 .build();
         NotificationManagerCompat.from(context).notify(sessionId, notification);
     }

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/receiver/NotificationReceiver.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/receiver/NotificationReceiver.java
@@ -24,8 +24,6 @@ public class NotificationReceiver extends BroadcastReceiver {
 
     private static final String KEY_TEXT = "text";
 
-    private static final int NOTIFICATION_ID = 1;
-
     public static Intent createIntent(Context context, int sessionId, String title, String text) {
         Intent intent = new Intent(context, NotificationReceiver.class);
         intent.putExtra(NotificationReceiver.KEY_SESSION_ID, sessionId);
@@ -59,6 +57,6 @@ public class NotificationReceiver extends BroadcastReceiver {
                 .setDefaults(NotificationCompat.DEFAULT_ALL)
                 .setPriority(priority)
                 .build();
-        NotificationManagerCompat.from(context).notify(NOTIFICATION_ID, notification);
+        NotificationManagerCompat.from(context).notify(sessionId, notification);
     }
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/util/AlarmUtil.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/util/AlarmUtil.java
@@ -17,8 +17,6 @@ public class AlarmUtil {
 
     private static final long REMIND_DURATION_MINUTES_FOR_START = TimeUnit.MINUTES.toMillis(10);
 
-    private static final int REQ_CODE_NOTIFICATION = 1001;
-
     public static void registerAlarm(@NonNull Context context, @NonNull Session session) {
         long time = session.stime.getTime() - REMIND_DURATION_MINUTES_FOR_START;
         // To develop notification, please uncomment this line
@@ -47,7 +45,7 @@ public class AlarmUtil {
                 DateUtil.getHourMinute(displayETime),
                 room);
         Intent intent = NotificationReceiver.createIntent(context, session.id, title, text);
-        return PendingIntent.getBroadcast(context, REQ_CODE_NOTIFICATION,
+        return PendingIntent.getBroadcast(context, session.id,
                 intent, PendingIntent.FLAG_UPDATE_CURRENT);
     }
 }


### PR DESCRIPTION
## Issue
-

## Overview (Required)
- Show group notification
  - e.g. If user check 4 sessions which start at 3/9 10:40, 4 notifications will be shown but they should be summarized like Gmail app.
- Set unique ID (=session ID) to PendingIntent and Notification not to override other PendingIntent and Notification objects.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | ![device-2017-02-07-224530](https://cloud.githubusercontent.com/assets/900756/22693764/f8cc786e-ed87-11e6-9867-67b3c50f47b6.png) ![device-2017-02-07-224542](https://cloud.githubusercontent.com/assets/900756/22693774/04be16dc-ed88-11e6-8c09-e6c8c3988ec2.png)

The second screen shot is captured when user expand group notification.
