### PR TITLE
Implement view for displaying sponsors

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="distributionType" value="DEFAULT_WRAPPED" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$" />
+            <option value="$PROJECT_DIR$/app" />
+          </set>
+        </option>
+        <option name="resolveModulePerSourceSet" value="false" />
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/app/src/main/assets/json/sponsors.json
+++ b/app/src/main/assets/json/sponsors.json
@@ -1,0 +1,193 @@
+[
+  {
+    "category": "Platinum Sponsors",
+    "sponsors": [
+      {
+        "site_url": "https://www.cyberagent.co.jp/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/ca.png"
+      },
+      {
+        "site_url": "https://abema.tv/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/abemaTV.png"
+      },
+      {
+        "site_url": "https://developers.google.com/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/google.png"
+      }
+    ]
+  },
+  {
+    "category": "Video Sponsor",
+    "sponsors": [
+      {
+        "site_url": "https://realm.io/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/realm.png"
+      }
+    ]
+  },
+
+  {
+    "category": "Power Supply Sponsors",
+    "sponsors": [
+      {
+        "site_url": "https://info.cookpad.com/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/cookpad.png"
+      },
+      {
+        "site_url": "http://dwango.co.jp/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/dwango.png"
+      }
+    ]
+  },
+
+  {
+    "category": "Network Sponsors",
+    "sponsors": [
+      {
+        "site_url": "http://jp.corp-sansan.com/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/sansan.jpg"
+      },
+      {
+        "site_url": "http://www.recruit-lifestyle.co.jp/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/recruitlifestyle.png"
+      }
+    ]
+  },
+
+  {
+    "category": "Lunch Sponsor",
+    "sponsors": [
+      {
+        "site_url": "https://www.wantedly.com/projects/9983",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/moneyforward.png"
+      }
+    ]
+  },
+
+  {
+    "category": "Snack Sponsors",
+    "sponsors": [
+      {
+        "site_url": "https://www.mercari.com/jp/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/mercari.png"
+      },
+      {
+        "site_url": "http://www.recruit-mp.co.jp/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/rmp.jpg"
+      },
+      {
+        "site_url": "https://www.justsystems.com/jp/employ/techcareer/?utm_source=droidkaigi2017&utm_medium=referral&utm_campaign=droidkaigi2017sponsored",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/justsystems.png"
+      }
+    ]
+  },
+
+  {
+    "category": "Lunch & Snack Sponsors",
+    "sponsors": [
+      {
+        "site_url": "https://hunza.jp/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/hunza.png"
+      },
+      {
+        "site_url": "http://diverse-inc.co.jp/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/diverse.png"
+      },
+      {
+        "site_url": "https://nohana.co.jp/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/nohana.png"
+      }
+    ]
+  },
+
+  {
+    "category": "Drink Sponsors",
+    "sponsors": [
+      {
+        "site_url": "https://pepabo.com/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/GMOpepabo.png"
+      },
+      {
+        "site_url": "http://www.yahoo.co.jp",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/yahoo.png"
+      }
+    ]
+  },
+
+  {
+    "category": ":sushi: Sponsor",
+    "sponsors": [
+      {
+        "site_url": "https://www.wantedly.com/companies/wantedly/projects?occupation_type=engineer",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/wantedly.png"
+      }
+    ]
+  },
+
+  {
+    "category": "Supporters",
+    "sponsors": [
+      {
+        "site_url": "http://speee.jp/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/speee.png"
+      },
+      {
+        "site_url": "https://bitjourney.com/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/bit-journey.png"
+      },
+      {
+        "site_url": "https://www.topgate.co.jp/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/topgate.png"
+      },
+      {
+        "site_url": "http://www.uphyca.com",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/uphyca.png"
+      },
+      {
+        "site_url": "https://s.nikkei.com/saiyo",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/nikkei.png"
+      },
+      {
+        "site_url": "https://pay.jp/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/pay_jp.png"
+      },
+      {
+        "site_url": "http://caraquri.com/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/caraquri.png"
+      },
+      {
+        "site_url": "http://www.saiyo.furyu.jp/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/furyu.png"
+      },
+      {
+        "site_url": "https://www.balto.io/ja/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/goodpatch.png"
+      },
+      {
+        "site_url": "https://deploygate.com",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/deploygate.png"
+      }
+    ]
+  },
+  {
+    "category": "Technical Support for Network",
+    "sponsors": [
+      {
+        "site_url": "https://conbu.net/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/conbu.png"
+      },
+      {
+        "site_url": "https://www.juniper.net/jp/jp/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/juniper-networks.png"
+      },
+      {
+        "site_url": "http://labo.dmm.com/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/DMMcom-labo.png"
+      },
+      {
+        "site_url": "http://www.bbtower.co.jp/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/BBTower.png"
+      }
+    ]
+  }
+]

--- a/app/src/main/assets/json/sponsors_en.json
+++ b/app/src/main/assets/json/sponsors_en.json
@@ -1,0 +1,193 @@
+[
+  {
+    "category": "Platinum Sponsors",
+    "sponsors": [
+      {
+        "site_url": "https://www.cyberagent.co.jp/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/ca.png"
+      },
+      {
+        "site_url": "https://abema.tv/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/abemaTV.png"
+      },
+      {
+        "site_url": "https://developers.google.com/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/google.png"
+      }
+    ]
+  },
+  {
+    "category": "Video Sponsor",
+    "sponsors": [
+      {
+        "site_url": "https://realm.io/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/realm.png"
+      }
+    ]
+  },
+
+  {
+    "category": "Power Supply Sponsors",
+    "sponsors": [
+      {
+        "site_url": "https://info.cookpad.com/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/cookpad.png"
+      },
+      {
+        "site_url": "http://dwango.co.jp/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/dwango.png"
+      }
+    ]
+  },
+
+  {
+    "category": "Network Sponsors",
+    "sponsors": [
+      {
+        "site_url": "http://jp.corp-sansan.com/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/sansan.jpg"
+      },
+      {
+        "site_url": "http://www.recruit-lifestyle.co.jp/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/recruitlifestyle.png"
+      }
+    ]
+  },
+
+  {
+    "category": "Lunch Sponsor",
+    "sponsors": [
+      {
+        "site_url": "https://www.wantedly.com/projects/9983",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/moneyforward.png"
+      }
+    ]
+  },
+
+  {
+    "category": "Snack Sponsors",
+    "sponsors": [
+      {
+        "site_url": "https://www.mercari.com/jp/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/mercari.png"
+      },
+      {
+        "site_url": "http://www.recruit-mp.co.jp/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/rmp.jpg"
+      },
+      {
+        "site_url": "https://www.justsystems.com/jp/employ/techcareer/?utm_source=droidkaigi2017&utm_medium=referral&utm_campaign=droidkaigi2017sponsored",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/justsystems.png"
+      }
+    ]
+  },
+
+  {
+    "category": "Lunch & Snack Sponsors",
+    "sponsors": [
+      {
+        "site_url": "https://hunza.jp/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/hunza.png"
+      },
+      {
+        "site_url": "http://diverse-inc.co.jp/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/diverse.png"
+      },
+      {
+        "site_url": "https://nohana.co.jp/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/nohana.png"
+      }
+    ]
+  },
+
+  {
+    "category": "Drink Sponsors",
+    "sponsors": [
+      {
+        "site_url": "https://pepabo.com/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/GMOpepabo.png"
+      },
+      {
+        "site_url": "http://www.yahoo.co.jp",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/yahoo.png"
+      }
+    ]
+  },
+
+  {
+    "category": ":sushi: Sponsor",
+    "sponsors": [
+      {
+        "site_url": "https://www.wantedly.com/companies/wantedly/projects?occupation_type=engineer",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/wantedly.png"
+      }
+    ]
+  },
+
+  {
+    "category": "Supporters",
+    "sponsors": [
+      {
+        "site_url": "http://speee.jp/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/speee.png"
+      },
+      {
+        "site_url": "https://bitjourney.com/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/bit-journey.png"
+      },
+      {
+        "site_url": "https://www.topgate.co.jp/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/topgate.png"
+      },
+      {
+        "site_url": "http://www.uphyca.com",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/uphyca.png"
+      },
+      {
+        "site_url": "https://s.nikkei.com/saiyo",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/nikkei.png"
+      },
+      {
+        "site_url": "https://pay.jp/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/pay_jp.png"
+      },
+      {
+        "site_url": "http://caraquri.com/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/caraquri.png"
+      },
+      {
+        "site_url": "http://www.saiyo.furyu.jp/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/furyu.png"
+      },
+      {
+        "site_url": "https://www.balto.io/ja/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/goodpatch.png"
+      },
+      {
+        "site_url": "https://deploygate.com",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/deploygate.png"
+      }
+    ]
+  },
+  {
+    "category": "Technical Support for Network",
+    "sponsors": [
+      {
+        "site_url": "https://conbu.net/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/conbu.png"
+      },
+      {
+        "site_url": "https://www.juniper.net/jp/jp/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/juniper-networks.png"
+      },
+      {
+        "site_url": "http://labo.dmm.com/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/DMMcom-labo.png"
+      },
+      {
+        "site_url": "http://www.bbtower.co.jp/",
+        "image_url": "https://droidkaigi.github.io/2017/images/sponsor/BBTower.png"
+      }
+    ]
+  }
+]

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/model/Sponsor.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/model/Sponsor.java
@@ -13,6 +13,6 @@ public class Sponsor {
     public String imageUrl;
 
     @Column
-    @SerializedName("url")
+    @SerializedName("site_url")
     public String url;
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/model/Sponsorship.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/model/Sponsorship.java
@@ -1,0 +1,10 @@
+package io.github.droidkaigi.confsched2017.model;
+
+import java.util.List;
+
+public class Sponsorship {
+
+    public String category;
+
+    public List<Sponsor> sponsors;
+}

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/util/AssetsUtil.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/util/AssetsUtil.java
@@ -1,0 +1,38 @@
+package io.github.droidkaigi.confsched2017.util;
+
+
+import android.content.Context;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import timber.log.Timber;
+
+public final class AssetsUtil {
+
+    private AssetsUtil() {
+        // No-op
+    }
+
+    /**
+     * Loads json string from the assets folder
+     *
+     * @param context      The calling context
+     * @param jsonFileName The file name of the json string
+     * @return The JSON string
+     */
+    public static String loadJSONFromAsset(Context context, final String jsonFileName) {
+        String json = null;
+        try {
+            InputStream is = context.getAssets().open("json/" + jsonFileName);
+            int size = is.available();
+            byte[] buffer = new byte[size];
+            is.read(buffer);
+            is.close();
+            json = new String(buffer, "UTF-8");
+        } catch (IOException e) {
+            Timber.e(AssetsUtil.class.getSimpleName(), e.getMessage(), e);
+        }
+        return json;
+    }
+}

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SponsorsFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SponsorsFragment.java
@@ -1,25 +1,53 @@
 package io.github.droidkaigi.confsched2017.view.fragment;
 
+import com.annimon.stream.Optional;
+
 import android.content.Context;
+import android.content.Intent;
+import android.graphics.Point;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v7.widget.DividerItemDecoration;
+import android.support.v7.widget.LinearLayoutManager;
+import android.view.Display;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import java.util.List;
+
 import javax.inject.Inject;
 
+import io.github.droidkaigi.confsched2017.R;
 import io.github.droidkaigi.confsched2017.databinding.FragmentSponsorsBinding;
-import io.github.droidkaigi.confsched2017.viewmodel.SponsorsViewModel;
+import io.github.droidkaigi.confsched2017.databinding.ViewSponsorCellBinding;
+import io.github.droidkaigi.confsched2017.databinding.ViewSponsorshipCellBinding;
+import io.github.droidkaigi.confsched2017.view.activity.SponsorsActivity;
+import io.github.droidkaigi.confsched2017.view.customview.ArrayRecyclerAdapter;
+import io.github.droidkaigi.confsched2017.view.customview.BindingHolder;
+import io.github.droidkaigi.confsched2017.view.helper.IntentHelper;
+import io.github.droidkaigi.confsched2017.viewmodel.SponsorViewModel;
+import io.github.droidkaigi.confsched2017.viewmodel.SponsorshipViewModel;
+import io.github.droidkaigi.confsched2017.viewmodel.SponsorshipsViewModel;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.disposables.CompositeDisposable;
+import io.reactivex.disposables.Disposable;
+import timber.log.Timber;
 
 public class SponsorsFragment extends BaseFragment {
 
     public static final String TAG = SponsorsFragment.class.getSimpleName();
 
     @Inject
-    SponsorsViewModel viewModel;
+    SponsorshipsViewModel viewModel;
+
+    @Inject
+    CompositeDisposable compositeDisposable;
 
     private FragmentSponsorsBinding binding;
+
+    private SponsorshipsAdapter adapter;
 
     public static SponsorsFragment newInstance() {
         return new SponsorsFragment();
@@ -34,17 +62,104 @@ public class SponsorsFragment extends BaseFragment {
         getComponent().inject(this);
     }
 
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        Disposable disposable = viewModel.convertSponsorShip()
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(
+                        this::renderSponsorships,
+                        throwable -> Timber.tag(TAG).e(throwable, "Failed to show sponsors.")
+                );
+        compositeDisposable.add(disposable);
+    }
+
+
     @Nullable
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+            Bundle savedInstanceState) {
         binding = FragmentSponsorsBinding.inflate(inflater, container, false);
         binding.setViewModel(viewModel);
-
         initView();
         return binding.getRoot();
     }
 
+    @Override
+    public void onStop() {
+        super.onStop();
+        compositeDisposable.dispose();
+    }
+
     private void initView() {
-        //
+        adapter = new SponsorshipsAdapter(getContext());
+        binding.recyclerView.setAdapter(adapter);
+        binding.recyclerView.addItemDecoration(new DividerItemDecoration(getContext(), DividerItemDecoration.VERTICAL));
+        binding.recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
+    }
+
+    private void renderSponsorships(List<SponsorshipViewModel> sponsorships) {
+        adapter.addAllWithNotify(sponsorships);
+    }
+
+    private static class SponsorAdapter extends ArrayRecyclerAdapter<SponsorViewModel, BindingHolder<ViewSponsorCellBinding>>
+            implements SponsorViewModel.Callback {
+
+        public SponsorAdapter(@NonNull Context context) {
+            super(context);
+        }
+
+        @Override
+        public BindingHolder<ViewSponsorCellBinding> onCreateViewHolder(ViewGroup parent, int viewType) {
+            return new BindingHolder<>(getContext(), parent, R.layout.view_sponsor_cell);
+        }
+
+        @Override
+        public void onBindViewHolder(BindingHolder<ViewSponsorCellBinding> holder, int position) {
+            SponsorViewModel viewModel = getItem(position);
+            viewModel.setCallback(this);
+            ViewSponsorCellBinding itemBinding = holder.binding;
+            itemBinding.sponsorLogo.setMinimumHeight(getScreenWidth() / 3);
+            itemBinding.setViewModel(viewModel);
+            itemBinding.executePendingBindings();
+        }
+
+        @Override
+        public void onClickSponsor(String url) {
+            Optional<Intent> intentOptional = IntentHelper.buildActionViewIntent(getContext(), url);
+            intentOptional.ifPresent(intent -> getContext().startActivity(intent));
+        }
+
+        private int getScreenWidth() {
+            Display display = ((SponsorsActivity) getContext()).getWindowManager().getDefaultDisplay();
+            Point size = new Point();
+            display.getSize(size);
+            return size.x;
+        }
+    }
+
+    private static class SponsorshipsAdapter extends
+            ArrayRecyclerAdapter<SponsorshipViewModel, BindingHolder<ViewSponsorshipCellBinding>> {
+
+        public SponsorshipsAdapter(@NonNull Context context) {
+            super(context);
+        }
+
+        @Override
+        public BindingHolder<ViewSponsorshipCellBinding> onCreateViewHolder(ViewGroup parent,
+                int viewType) {
+            return new BindingHolder<>(getContext(), parent, R.layout.view_sponsorship_cell);
+        }
+
+        @Override
+        public void onBindViewHolder(BindingHolder<ViewSponsorshipCellBinding> holder, int position) {
+            SponsorshipViewModel viewModel = getItem(position);
+            ViewSponsorshipCellBinding itemBinding = holder.binding;
+            SponsorAdapter adapter = new SponsorAdapter(holder.itemView.getContext());
+            adapter.addAllWithNotify(viewModel.getSponsors());
+            itemBinding.sponsorshipRecyclerView.setAdapter(adapter);
+            itemBinding.setViewModel(viewModel);
+            itemBinding.executePendingBindings();
+        }
     }
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/SponsorViewModel.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/SponsorViewModel.java
@@ -2,17 +2,21 @@ package io.github.droidkaigi.confsched2017.viewmodel;
 
 import android.databinding.BaseObservable;
 import android.support.annotation.NonNull;
+import android.view.View;
 
 import javax.inject.Inject;
 
 import io.github.droidkaigi.confsched2017.model.Sponsor;
 
-public final class SponsorsViewModel extends BaseObservable implements ViewModel {
+public final class SponsorViewModel extends BaseObservable implements ViewModel {
 
     private Callback callback;
 
+    private Sponsor sponsor;
+
     @Inject
-    SponsorsViewModel() {
+    SponsorViewModel(Sponsor sponsor) {
+        this.sponsor = sponsor;
     }
 
     public void setCallback(@NonNull Callback callback) {
@@ -24,8 +28,18 @@ public final class SponsorsViewModel extends BaseObservable implements ViewModel
         this.callback = null;
     }
 
+    public void onClickSponsor(@SuppressWarnings("UnusedParameters") View view) {
+        if (callback != null) {
+            callback.onClickSponsor(sponsor.url);
+        }
+    }
+
+    public Sponsor getSponsor() {
+        return sponsor;
+    }
+
     public interface Callback {
 
-        void onClickSponsor(Sponsor sponsor);
+        void onClickSponsor(String url);
     }
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/SponsorshipViewModel.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/SponsorshipViewModel.java
@@ -1,0 +1,53 @@
+package io.github.droidkaigi.confsched2017.viewmodel;
+
+import com.annimon.stream.Collectors;
+import com.annimon.stream.Stream;
+
+import android.databinding.BaseObservable;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import io.github.droidkaigi.confsched2017.model.Sponsorship;
+
+public final class SponsorshipViewModel extends BaseObservable implements ViewModel {
+
+    private Sponsorship sponsorship;
+
+    private String category;
+
+    private List<SponsorViewModel> sponsors;
+
+    @Inject
+    SponsorshipViewModel(Sponsorship sponsorship) {
+        this.sponsorship = sponsorship;
+        this.category = sponsorship.category;
+        this.sponsors = setSponsorship(sponsorship);
+    }
+
+    @Override
+    public void destroy() {
+        // No-op
+    }
+
+    public Sponsorship getSponsorship() {
+        return sponsorship;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public List<SponsorViewModel> getSponsors() {
+        return sponsors;
+    }
+
+    private List<SponsorViewModel> setSponsorship(Sponsorship sponsorship) {
+        return Stream.of(sponsorship.sponsors)
+                .map(sponsor -> {
+                    return new SponsorViewModel(sponsor);
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/SponsorshipsViewModel.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/SponsorshipsViewModel.java
@@ -1,0 +1,63 @@
+package io.github.droidkaigi.confsched2017.viewmodel;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import com.annimon.stream.Collectors;
+import com.annimon.stream.Stream;
+
+import android.content.Context;
+import android.databinding.BaseObservable;
+import android.support.annotation.Nullable;
+
+import java.lang.reflect.Type;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import io.github.droidkaigi.confsched2017.R;
+import io.github.droidkaigi.confsched2017.model.Sponsorship;
+import io.github.droidkaigi.confsched2017.util.AssetsUtil;
+import io.reactivex.Single;
+
+public final class SponsorshipsViewModel extends BaseObservable implements ViewModel {
+
+    private Context context;
+
+    @Inject
+    SponsorshipsViewModel(Context context) {
+        this.context = context;
+    }
+
+    @Override
+    public void destroy() {
+        // No-op
+    }
+
+    public Single<List<SponsorshipViewModel>> convertSponsorShip() {
+        return loadSponsors().map(sponsorships ->
+                Stream.of(sponsorships).map(SponsorshipViewModel::new).collect(Collectors.toList()));
+    }
+
+
+    private Single<List<Sponsorship>> loadSponsors() {
+        return Single.create(emitter -> {
+            final String json = AssetsUtil.loadJSONFromAsset(context, context.getString(R.string.sponsors_file));
+            emitter.onSuccess(transformSponsorships(json));
+        });
+    }
+
+    /**
+     * Transforms from a valid json string to a List of {@link Sponsorship}.
+     *
+     * @param json A json representing a list of sponsors.
+     * @return List of {@link Sponsorship}.
+     */
+    @Nullable
+    private List<Sponsorship> transformSponsorships(String json) {
+        final Gson gson = new Gson();
+        final Type listType = new TypeToken<List<Sponsorship>>() {
+        }.getType();
+        return gson.fromJson(json, listType);
+    }
+}

--- a/app/src/main/res/drawable/rectangle_border_grey200.xml
+++ b/app/src/main/res/drawable/rectangle_border_grey200.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+        android:shape="rectangle"
+        >
+    <solid android:color="@android:color/white" />
+    <stroke
+            android:width="@dimen/sponsor_image_border"
+            android:color="@color/grey200"
+            />
+    <padding
+            android:bottom="@dimen/user_image_border"
+            android:left="@dimen/user_image_border"
+            android:right="@dimen/user_image_border"
+            android:top="@dimen/user_image_border"
+            />
+</shape>

--- a/app/src/main/res/layout/fragment_sponsors.xml
+++ b/app/src/main/res/layout/fragment_sponsors.xml
@@ -5,7 +5,7 @@
 
         <variable
                 name="viewModel"
-                type="io.github.droidkaigi.confsched2017.viewmodel.SponsorsViewModel"
+                type="io.github.droidkaigi.confsched2017.viewmodel.SponsorshipsViewModel"
                 />
     </data>
 
@@ -14,12 +14,11 @@
             android:layout_height="match_parent"
             >
 
-        <TextView
-                style="@style/TextTitle"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_centerInParent="true"
-                android:text="@string/sponsors"
+        <android.support.v7.widget.RecyclerView
+                android:id="@+id/recycler_view"
+                style="@style/BaseRecyclerView"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
                 />
 
     </RelativeLayout>

--- a/app/src/main/res/layout/view_sponsor_cell.xml
+++ b/app/src/main/res/layout/view_sponsor_cell.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        >
+
+    <data>
+
+        <variable
+                name="viewModel"
+                type="io.github.droidkaigi.confsched2017.viewmodel.SponsorViewModel"
+                />
+    </data>
+
+    <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/sponsor_image_margin"
+            android:layout_marginEnd="@dimen/sponsor_image_margin"
+            android:layout_marginStart="@dimen/sponsor_image_margin"
+            android:background="?attr/selectableItemBackground"
+            android:clickable="true"
+            android:onClick="@{viewModel::onClickSponsor}"
+            >
+
+        <ImageView
+                android:id="@+id/sponsor_logo"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerInParent="true"
+                android:background="@drawable/rectangle_border_grey200"
+                android:maxHeight="@dimen/sponsor_image_height"
+                android:padding="@dimen/sponsor_image_margin"
+                android:scaleType="centerInside"
+                app:photoImageUrl="@{viewModel.sponsor.imageUrl}"
+                />
+    </RelativeLayout>
+</layout>

--- a/app/src/main/res/layout/view_sponsorship_cell.xml
+++ b/app/src/main/res/layout/view_sponsorship_cell.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        >
+
+    <data>
+
+        <variable
+                name="viewModel"
+                type="io.github.droidkaigi.confsched2017.viewmodel.SponsorshipViewModel"
+                />
+    </data>
+
+    <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@drawable/clickable_white"
+            android:clipToPadding="false"
+            android:orientation="vertical"
+            android:paddingBottom="@dimen/space_4dp"
+            android:paddingTop="@dimen/space_4dp"
+            android:stateListAnimator="@animator/raise"
+            >
+
+        <TextView
+                android:id="@+id/txt_sponsor_category"
+                style="@style/TextBody2"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/session_table_header_row_height"
+                android:gravity="center"
+                android:text="@{viewModel.category}"
+                android:textColor="@color/black"
+                android:textStyle="bold"
+                />
+
+        <android.support.v7.widget.RecyclerView
+                android:id="@+id/sponsorship_recycler_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layoutManager="android.support.v7.widget.GridLayoutManager"
+                app:spanCount="3"
+                />
+    </LinearLayout>
+</layout>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -33,6 +33,7 @@
     <string name="info_dev_info_title">開発情報</string>
     <!-- Sponsors -->
     <string name="sponsors">スポンサー</string>
+    <string name="sponsors_file">sponsors.json</string>
     <!-- Contributors -->
     <string name="contributors">コントリビュータ</string>
     <string name="contributors_people">(%1$d人)</string>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -69,4 +69,8 @@
     <dimen name="contributor_image_margin_bottom">@dimen/space_8dp</dimen>
     <dimen name="contributor_cell_margin_bottom">@dimen/space_16dp</dimen>
 
+    <!-- Sponsor -->
+    <dimen name="sponsor_image_height">80dp</dimen>
+    <dimen name="sponsor_image_margin">@dimen/space_8dp</dimen>
+    <dimen name="sponsor_image_border">4dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,7 +56,7 @@
 
     <!-- Sponsors -->
     <string name="sponsors">Sponsors</string>
-
+    <string name="sponsors_file">sponsors_en.json</string>
 
     <!-- Contributors -->
     <string name="contributors">Contributors</string>


### PR DESCRIPTION
## Issue
- #76 

## Overview (Required)
- Displays sponsors from a localized JSON strings in the assets folder.
- Uses recyclever view to display a header and another recyclever to display sponsors.
- When a sponsor is clicked it loads their website in a webview.
- Tried to implement the design per the spec provided in #76 

## TODO

- [x]  Add more sponsors to the sponsors json files.
- [x] Remove manual edit of the english strings as manual edits aren't allowed.
- [x] Clean up code.
- [x] Be consistent with category's name capitalization.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/73175/22818504/ee9d941a-efb0-11e6-9e8e-533e5a78935c.png" width="300" />