### PR TITLE
Change parent style for Toolbar to ThemeOverlay.AppCompat.Dark

### DIFF
--- a/app/src/main/res/values/styles_base.xml
+++ b/app/src/main/res/values/styles_base.xml
@@ -103,9 +103,16 @@
         <item name="theme">@style/ToolbarTheme</item>
     </style>
 
-    <style name="ToolbarTheme" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="ToolbarTheme" parent="ThemeOverlay.AppCompat.Dark.ActionBar">
         <item name="android:textColorPrimary">@color/toolbar_text</item>
         <item name="android:textColorSecondary">@color/toolbar_text</item>
+        <item name="colorControlActivated">@color/white</item>
+        <item name="searchViewStyle">@style/SearchViewStyle</item>
+    </style>
+
+    <style name="SearchViewStyle" parent="Widget.AppCompat.SearchView">
+        <item name="queryBackground">@null</item>
+        <item name="submitBackground">@null</item>
     </style>
 
     <style name="BaseActionBar" parent="@style/Widget.AppCompat.Light.ActionBar.Solid">


### PR DESCRIPTION
## Issue
- #163

## Overview (Required)
- Parent style for Toolbar should be ThemeOverlay.AppCompat.XX
- Specify @color/white as colorControlActivated for text selection handle

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/455504/22696218/8d0cf4e2-ed90-11e6-9d70-30780ced284c.png" width="300" />


## Note

- I think ThemeOverlay.AppCompat.Dark.ActionBar is more appropriate. But this style change searchViewStyle, so it's up to you.
- This is a screenshot when use ThemeOverlay.AppCompat.Dark.ActionBar as parent of ToolbarTheme. Underline and Search Icon disappear.

<img src="https://cloud.githubusercontent.com/assets/455504/22696028/0f1cb64e-ed90-11e6-9909-896c3d0e4768.png" width="300" />


