### PR TITLE
Apply white theme to text select handle and focus at search screen.

### DIFF
--- a/app/src/main/res/layout/view_search_compat.xml
+++ b/app/src/main/res/layout/view_search_compat.xml
@@ -17,6 +17,7 @@
 
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
         android:id="@id/search_bar"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -79,6 +80,7 @@
 
             <view
                     android:id="@id/search_src_text"
+                    style="@style/WhiteSelector"
                     class="android.support.v7.widget.SearchView$SearchAutoComplete"
                     android:layout_width="0dp"
                     android:layout_height="36dip"
@@ -98,6 +100,7 @@
                     android:paddingRight="@dimen/abc_dropdownitem_text_padding_right"
                     android:textColor="@color/white"
                     android:textColorHint="@color/white_alpha_95"
+                    app:theme="@style/WhiteSelector"
                     />
 
             <ImageView

--- a/app/src/main/res/values/styles_base.xml
+++ b/app/src/main/res/values/styles_base.xml
@@ -35,6 +35,11 @@
         <item name="android:clickable">true</item>
     </style>
 
+    <!--==================== Edit Text ====================-->
+    <style name="WhiteSelector">
+        <item name="colorControlActivated">@color/white</item>
+        <item name="android:textCursorDrawable">@color/white</item>
+    </style>
 
     <!--==================== Button ====================-->
     <style name="Button" parent="Widget.AppCompat.Button">


### PR DESCRIPTION
## Issue
- #163 

## Overview (Required)
- Apply white theme to text select handle and focus at search screen.
```
<item name="colorControlActivated">@color/white</item>
<item name="android:textCursorDrawable">@color/white</item>
```

## Links
- http://qiita.com/konifar/items/47d467e3574c9228fdc8
- http://qiita.com/litmon/items/56f58ec241e4d9e1a24a#_reference-0fd3131de2fe09df90f5

## Screenshot
Before | After
:--: | :--:
<img src="https://cloud.githubusercontent.com/assets/5351226/22698498/11755b1e-ed98-11e6-89eb-198198ffc872.png" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/5351226/22698312/90cf8ca0-ed97-11e6-9c3b-336aec1d011c.png" width="300" />
