### PR TITLE
Change search page background to translucent.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -69,7 +69,7 @@
                 android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation"
                 android:exported="false"
                 android:label="@string/search"
-                android:theme="@style/AppTheme.ColoredStatusBar"
+                android:theme="@style/AppTheme.Translucent"
                 />
 
         <activity android:name=".view.activity.LicensesActivity"

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -31,7 +31,7 @@
         <item name="android:windowContentOverlay">@null</item>
         <item name="android:windowIsFloating">false</item>
         <item name="android:windowIsTranslucent">true</item>
-        <item name="android:windowNoTitle">true</item>
+        <item name="windowNoTitle">true</item>
         <item name="windowActionBar">false</item>
     </style>
 


### PR DESCRIPTION
## Issue
- #162 

## Overview (Required)
- Fix `AppTheme.Translucent` style.
- Apply `AppTheme.Translucent` to `SearchActivity`.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://cloud.githubusercontent.com/assets/949882/22699775/d523c5d4-ed9b-11e6-84ff-c5b78ffc7f57.png" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/949882/22699798/e9f78112-ed9b-11e6-9fc3-9817c34560fb.png" width="300" />
