### PR TITLE
Fixed the date is reset When returning from SessionDetailActivity

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SessionsFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SessionsFragment.java
@@ -206,7 +206,9 @@ public class SessionsFragment extends BaseFragment implements SessionViewModel.C
 
         adapter.reset(adjustedSessionViewModels);
 
-        binding.txtDate.setText(adjustedSessionViewModels.get(0).getFormattedDate());
+        if (TextUtils.isEmpty(binding.txtDate.getText())) {
+            binding.txtDate.setText(adjustedSessionViewModels.get(0).getFormattedDate());
+        }
     }
 
     private void renderHeaderRow(List<Room> rooms) {


### PR DESCRIPTION
## Issue
-

## Overview (Required)
- When returning from SessionDetailActivity, the date is reset.(Please see screenshot. The day has changed from `3月10日` to `3月9日`.)

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://cloud.githubusercontent.com/assets/1322515/22702336/b304117c-eda3-11e6-8ffd-ac43a0cf47af.gif" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/1322515/22702339/b5c02c84-eda3-11e6-9eff-30a9b2cb50c5.gif" width="300" />





