### PR TITLE
skip redundant tests; jacocoTestReportDevelop includes app:testDevelopDebugUnitTest

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
   environment:
     ANDROID_HOME: /usr/local/android-sdk-linux
     JAVA_OPTS: "-Xms512m -Xmx1024m"
-    GRADLE_OPTS: '-Dorg.gradle.parallel=false -Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-Xmx1056m -XX:+HeapDumpOnOutOfMemoryError"'
+    GRADLE_OPTS: '-Dorg.gradle.parallel=false -Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-Xmx1560m -XX:+HeapDumpOnOutOfMemoryError"'
     TERM: dumb
 
 dependencies:
@@ -22,7 +22,7 @@ dependencies:
 test:
   override:
     - ./gradlew assembleProductionDebug
-    - ./gradlew check
+    - ./gradlew lint
     - ./gradlew jacocoTestReportDevelop
     - find . -name app*debug.apk -exec cp {} $CIRCLE_ARTIFACTS/ \;
 


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)

- Skip redundant tests  in CI
- `./gradlew check` does `lint`, `test`, and `assemble` for **all** the variants, but we need just a few
- We just need `assembleProductionDebug` executed above
- Because `jacocoTestReportDevelop` includes `app:testDevelopDebugUnitTest` , it is considered enough as unit testing

