### PR TITLE
Added checkLicenses to test tasks

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -23,6 +23,7 @@ test:
   override:
     - ./gradlew assembleProductionDebug
     - ./gradlew lint
+    - ./gradlew checkLicenses
     - ./gradlew jacocoTestReportDevelop
     - find . -name app*debug.apk -exec cp {} $CIRCLE_ARTIFACTS/ \;
 


### PR DESCRIPTION
## Issue
- None

## Overview (Required)
- Stopped running `check` task, then CircleCI doesn't run `checkLicense` too.
- So I added `checkLicense` to test tasks of CircleCI.

## Links
- https://github.com/DroidKaigi/conference-app-2017/pull/195#discussion_r99980201
