### PR TITLE
Fix crash when SessionDetailFragment inflated before loadSession completed

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SessionDetailFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SessionDetailFragment.java
@@ -18,7 +18,6 @@ import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.Window;
 
 import javax.inject.Inject;
 
@@ -98,7 +97,10 @@ public class SessionDetailFragment extends BaseFragment implements SessionDetail
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
-                        () -> initTheme(),
+                        () -> {
+                            initTheme();
+                            binding.setViewModel(viewModel);
+                        },
                         throwable -> Log.e(TAG, "Failed to find session.", throwable)
                 );
         compositeDisposable.add(disposable);

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/SessionDetailViewModel.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/SessionDetailViewModel.java
@@ -37,16 +37,16 @@ public class SessionDetailViewModel extends BaseObservable implements ViewModel 
     private String sessionTitle;
 
     @ColorRes
-    private int sessionVividColorResId;
+    private int sessionVividColorResId = R.color.white;
 
     @ColorRes
-    private int sessionPaleColorResId;
+    private int sessionPaleColorResId = R.color.white;
 
     @StyleRes
-    private int sessionThemeResId;
+    private int sessionThemeResId = R.color.white;
 
     @StringRes
-    private int languageResId;
+    private int languageResId = R.string.lang_en;
 
     private String sessionTimeRange;
 


### PR DESCRIPTION
## Issue
- Open SessionDetailActivity, the app crashes extremely rarely.

```
E/AndroidRuntime: FATAL EXCEPTION: main
                  Process: io.github.droidkaigi.confsched2017.develop.debug, PID: 24060
                  android.content.res.Resources$NotFoundException: String resource ID #0x0
                      at android.content.res.Resources.getText(Resources.java:299)
                      at android.widget.TextView.setText(TextView.java:4132)
                      at io.github.droidkaigi.confsched2017.databinding.FragmentSessionDetailBinding.executeBindings(FragmentSessionDetailBinding.java:269)
                      at android.databinding.ViewDataBinding.executePendingBindings(ViewDataBinding.java:355)
                      at android.databinding.ViewDataBinding$6.run(ViewDataBinding.java:172)
                      at android.databinding.ViewDataBinding$5.onViewAttachedToWindow(ViewDataBinding.java:142)
                      at android.view.View.dispatchAttachedToWindow(View.java:13536)
                      at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:2688)
                      at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:2695)
                      at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:2695)
                      at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:2695)
                      at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:2695)
                      at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:2695)
                      at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:2695)
                      at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:1299)
                      at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1061)
                      at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:5885)
                      at android.view.Choreographer$CallbackRecord.run(Choreographer.java:767)
                      at android.view.Choreographer.doCallbacks(Choreographer.java:580)
                      at android.view.Choreographer.doFrame(Choreographer.java:550)
                      at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:753)
                      at android.os.Handler.handleCallback(Handler.java:739)
                      at android.os.Handler.dispatchMessage(Handler.java:95)
                      at android.os.Looper.loop(Looper.java:135)
                      at android.app.ActivityThread.main(ActivityThread.java:5254)
                      at java.lang.reflect.Method.invoke(Native Method)
                      at java.lang.reflect.Method.invoke(Method.java:372)
                      at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:903)
                      at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:698)
```

## Overview (Required)
- SessionDetailViewModel's value were set asynchronously.
- If SessionDetailFragment was inflated before setting ViewModel's value, resource value was set 0. 
- Then app access resource id 0x0, but such a resource dose not exist.

So I set initial value.
(Sorry, I don't know default color and set R.color.white. )

## Reproduce step

1. Set breakpoint at line 95 of SessionDeteilViewModel.
1. Run debug 'app'.
1. Open any session then stop at the breakpoint.
1. Resume app.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

