### PR TITLE
Fix unnecessary page shown when little horizontal scrolled

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SessionsFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SessionsFragment.java
@@ -159,15 +159,14 @@ public class SessionsFragment extends BaseFragment implements SessionViewModel.C
         adapter = new SessionsAdapter(getContext());
         binding.recyclerView.setAdapter(adapter);
 
-        final ClickGestureCanceler clickCanceler = new ClickGestureCanceler(getContext(), binding.recyclerView);
+        final ClickGestureCanceller clickCanceller = new ClickGestureCanceller(getContext(), binding.recyclerView);
 
         binding.root.setOnTouchListener((v, event) -> {
-            clickCanceler.sendCancelIfScrolling(event);
+            clickCanceller.sendCancelIfScrolling(event);
 
             MotionEvent e = MotionEvent.obtain(event);
             e.setLocation(e.getX() + binding.root.getScrollX(), e.getY() - binding.headerRow.getHeight());
             binding.recyclerView.forceToDispatchTouchEvent(e);
-
             return false;
         });
 
@@ -257,11 +256,11 @@ public class SessionsFragment extends BaseFragment implements SessionViewModel.C
         }
     }
 
-    private static class ClickGestureCanceler
+    private static class ClickGestureCanceller
     {
         private GestureDetector gestureDetector;
 
-        ClickGestureCanceler(final Context context, final TouchlessTwoWayView targetView) {
+        ClickGestureCanceller(final Context context, final TouchlessTwoWayView targetView) {
             gestureDetector = new GestureDetector(context, new GestureDetector.OnGestureListener() {
                 private boolean ignoreMotionEventOnScroll = false;
 

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SessionsFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SessionsFragment.java
@@ -202,13 +202,13 @@ public class SessionsFragment extends BaseFragment implements SessionViewModel.C
         });
 
         binding.root.setOnTouchListener((v, event) -> {
-            boolean isHandle = gestureDetector.onTouchEvent(event);
+            gestureDetector.onTouchEvent(event);
 
             MotionEvent e = MotionEvent.obtain(event);
             e.setLocation(e.getX() + binding.root.getScrollX(), e.getY() - binding.headerRow.getHeight());
             binding.recyclerView.forceToDispatchTouchEvent(e);
 
-            return isHandle;
+            return false;
         });
 
         ViewUtil.addOneTimeOnGlobalLayoutListener(binding.headerRow, () -> {


### PR DESCRIPTION
## Issue
- #205

## Overview (Required)

This reason is fired clicked event in RecyclerView because position X does not changes between ACTION_DOWN and ACTION_UP.

I send cancelling motion event when horizontal scrolling.

But, I can't resolve when start scrolling with "long tapped" above session cell.
In this case, still session detail page shown when scroll ended.

## Links

This fix is inspired from ``RecyclerView.java``.

- https://android.googlesource.com/platform/frameworks/support/+/refs/heads/master/v7/recyclerview/src/android/support/v7/widget/RecyclerView.java#1927

## Screenshot
Before | After
:--: | :--:
<img src="https://cloud.githubusercontent.com/assets/401369/22725717/81465248-ee12-11e6-8809-274fc61c6e5d.gif" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/401369/22725727/98e42010-ee12-11e6-862d-af9f3861f446.gif" width="300" />

