### PR TITLE
Enable alarm even if device is doze mode

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/util/AlarmUtil.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/util/AlarmUtil.java
@@ -4,6 +4,7 @@ import android.app.AlarmManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.support.annotation.NonNull;
 
 import java.util.Date;
@@ -23,7 +24,11 @@ public class AlarmUtil {
         //time = System.currentTimeMillis() + 5000;
         if (System.currentTimeMillis() < time) {
             AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
-            alarmManager.set(AlarmManager.RTC_WAKEUP, time, createAlarmIntent(context, session));
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                alarmManager.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, time, createAlarmIntent(context, session));
+            } else {
+                alarmManager.set(AlarmManager.RTC_WAKEUP, time, createAlarmIntent(context, session));
+            }
         }
     }
 


### PR DESCRIPTION
## Issue
-

## Overview (Required)
- From Android M, doze / app standby are introduced, which delay alarm manager.
- To avoid such case, I use `setAndAllowWhileIdle` instead of `set` on Android M and later.

## Links
- https://developer.android.com/training/monitoring-device-state/doze-standby.html?hl=ja#assessing_your_app
- https://developer.android.com/reference/android/app/AlarmManager.html?hl=ja
  - `This type of alarm must only be used for situations where it is actually required that the alarm go off while in idle -- a reasonable example would be for a calendar notification that should make a sound so the user is aware of it.`

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
