### PR TITLE
Add swipe refresh to contributors

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/repository/contributors/ContributorsRepository.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/repository/contributors/ContributorsRepository.java
@@ -49,7 +49,7 @@ public class ContributorsRepository {
     }
 
 
-    private Single<List<Contributor>> findAllFromRemote() {
+    public Single<List<Contributor>> findAllFromRemote() {
         return remoteDataSourse.findAll().map(
                 contributors -> {
                     refreshCache(contributors);

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/repository/contributors/ContributorsRepository.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/repository/contributors/ContributorsRepository.java
@@ -30,6 +30,10 @@ public class ContributorsRepository {
         this.isDirty = true;
     }
 
+    public void setDirty(boolean isDirty) {
+        this.isDirty = isDirty;
+    }
+
     public Single<List<Contributor>> findAll() {
         if (cachedContributors != null && !cachedContributors.isEmpty() && !isDirty) {
             return Single.create(emitter -> {
@@ -49,7 +53,7 @@ public class ContributorsRepository {
     }
 
 
-    public Single<List<Contributor>> findAllFromRemote() {
+    private Single<List<Contributor>> findAllFromRemote() {
         return remoteDataSource.findAll().map(
                 contributors -> {
                     refreshCache(contributors);

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/ContributorsFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/ContributorsFragment.java
@@ -63,13 +63,7 @@ public class ContributorsFragment extends BaseFragment implements ContributorsVi
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         viewModel.setCallback(this);
-        Disposable disposable = viewModel.getContributors(false)
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(
-                        this::renderContributors,
-                        throwable -> Timber.tag(TAG).e(throwable, "Failed to show contributors.")
-                );
-        compositeDisposable.add(disposable);
+        getContributors(false);
     }
 
     @Nullable
@@ -114,7 +108,11 @@ public class ContributorsFragment extends BaseFragment implements ContributorsVi
 
     @Override
     public void onSwipeRefresh() {
-        Disposable disposable = viewModel.getContributors(true)
+        getContributors(true);
+    }
+
+    private void getContributors(boolean refresh) {
+        Disposable disposable = viewModel.getContributors(refresh)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                         this::renderContributors,

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/ContributorsFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/ContributorsFragment.java
@@ -63,7 +63,7 @@ public class ContributorsFragment extends BaseFragment implements ContributorsVi
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         viewModel.setCallback(this);
-        getContributors(false);
+        loadContributors(false);
     }
 
     @Nullable
@@ -108,10 +108,10 @@ public class ContributorsFragment extends BaseFragment implements ContributorsVi
 
     @Override
     public void onSwipeRefresh() {
-        getContributors(true);
+        loadContributors(true);
     }
 
-    private void getContributors(boolean refresh) {
+    private void loadContributors(boolean refresh) {
         Disposable disposable = viewModel.getContributors(refresh)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/ContributorsFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/ContributorsFragment.java
@@ -63,7 +63,7 @@ public class ContributorsFragment extends BaseFragment implements ContributorsVi
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         viewModel.setCallback(this);
-        Disposable disposable = viewModel.getContributors()
+        Disposable disposable = viewModel.getContributors(false)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                         this::renderContributors,
@@ -95,19 +95,32 @@ public class ContributorsFragment extends BaseFragment implements ContributorsVi
     }
 
     private void renderContributors(List<ContributorViewModel> contributors) {
-        adapter.addAllWithNotify(contributors);
+        adapter.clear();
+        adapter.addAll(contributors);
+        adapter.notifyDataSetChanged();
 
         Optional.ofNullable(getActivity())
                 .select(AppCompatActivity.class)
                 .map(AppCompatActivity::getSupportActionBar)
                 .ifPresent(actionBar -> actionBar.setTitle(
-                        actionBar.getTitle() + " " + getString(R.string.contributors_people, contributors.size())));
+                        getString(R.string.contributors) + " " + getString(R.string.contributors_people, contributors.size())));
     }
 
     @Override
     public void onClickContributor(String htmlUrl) {
         Optional<Intent> intentOptional = IntentHelper.buildActionViewIntent(getContext(), htmlUrl);
         intentOptional.ifPresent(this::startActivity);
+    }
+
+    @Override
+    public void onSwipeRefresh() {
+        Disposable disposable = viewModel.getContributors(true)
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(
+                        this::renderContributors,
+                        throwable -> Timber.tag(TAG).e(throwable, "Failed to show contributors.")
+                );
+        compositeDisposable.add(disposable);
     }
 
     private static class Adapter

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/ContributorsViewModel.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/ContributorsViewModel.java
@@ -43,13 +43,10 @@ public final class ContributorsViewModel extends BaseObservable implements ViewM
     }
 
     public Single<List<ContributorViewModel>> getContributors(boolean refresh) {
-        Single<List<Contributor>> single;
         if (refresh) {
-            single = contributorsRepository.findAllFromRemote();
-        } else {
-            single = contributorsRepository.findAll();
+            contributorsRepository.setDirty(true);
         }
-        return single.map(contributors -> {
+        return contributorsRepository.findAll().map(contributors -> {
             setLoadingVisibility(View.GONE);
             setRefreshing(false);
             return Stream.of(contributors).map(contributor -> {

--- a/app/src/main/res/layout/fragment_contributors.xml
+++ b/app/src/main/res/layout/fragment_contributors.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     >
 
     <data>
@@ -15,11 +16,13 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <RelativeLayout
+        <android.support.v4.widget.SwipeRefreshLayout
+            android:id="@+id/swipe_refresh_layout"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            app:refreshing="@{viewModel.refreshing}"
+            app:onRefreshListener="@{viewModel::onSwipeRefresh}"
             >
-
 
             <android.support.v7.widget.RecyclerView
                 android:id="@+id/recycler_view"
@@ -28,7 +31,7 @@
                 android:layout_height="match_parent"
                 />
 
-        </RelativeLayout>
+        </android.support.v4.widget.SwipeRefreshLayout>
 
         <FrameLayout
             android:layout_width="match_parent"


### PR DESCRIPTION
## Issue
-

## Overview (Required)
- This project is frequently contributed so I added swipe to refresh to contributors page.
- When user swipes to refresh, contributors will be fetched from GitHub API even if data is cached.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | ![device-2017-02-08-214846](https://cloud.githubusercontent.com/assets/900756/22737868/6b3a83ee-ee48-11e6-8e18-f842d7cc3aa6.png)

