### PR TITLE
remove unnecessary try catch in SingleOnSubscribe.subscribe() 

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/repository/contributors/ContributorsRepository.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/repository/contributors/ContributorsRepository.java
@@ -33,11 +33,7 @@ public class ContributorsRepository {
     public Single<List<Contributor>> findAll() {
         if (cachedContributors != null && !cachedContributors.isEmpty() && !isDirty) {
             return Single.create(emitter -> {
-                try {
-                    emitter.onSuccess(new ArrayList<>(cachedContributors.values()));
-                } catch (Exception e) {
-                    emitter.onError(e);
-                }
+                emitter.onSuccess(new ArrayList<>(cachedContributors.values()));
             });
         }
 

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/repository/sessions/MySessionsLocalDataSource.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/repository/sessions/MySessionsLocalDataSource.java
@@ -34,11 +34,7 @@ public class MySessionsLocalDataSource implements MySessionsDataSource {
         // TODO
         if (mySessionRelation().isEmpty()) {
             return Single.create(emitter -> {
-                try {
-                    emitter.onSuccess(new ArrayList<>());
-                } catch (Exception e) {
-                    emitter.onError(e);
-                }
+                emitter.onSuccess(new ArrayList<>());
             });
         } else {
             return mySessionRelation().selector().executeAsObservable().toList()

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/repository/sessions/MySessionsRepository.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/repository/sessions/MySessionsRepository.java
@@ -32,11 +32,7 @@ public class MySessionsRepository implements MySessionsDataSource {
     public Single<List<MySession>> findAll() {
         if (cachedMySessions != null && !cachedMySessions.isEmpty()) {
             return Single.create(emitter -> {
-                try {
-                    emitter.onSuccess(new ArrayList<>(cachedMySessions.values()));
-                } catch (Exception e) {
-                    emitter.onError(e);
-                }
+                emitter.onSuccess(new ArrayList<>(cachedMySessions.values()));
             });
         }
 

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/repository/sessions/SessionsRepository.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/repository/sessions/SessionsRepository.java
@@ -37,11 +37,7 @@ public class SessionsRepository implements SessionsDataSource {
     public Single<List<Session>> findAll(String languageId) {
         if (hasCacheSessions()) {
             return Single.create(emitter -> {
-                try {
-                    emitter.onSuccess(new ArrayList<>(cachedSessions.values()));
-                } catch (Exception e) {
-                    emitter.onError(e);
-                }
+                emitter.onSuccess(new ArrayList<>(cachedSessions.values()));
             });
         }
 
@@ -56,11 +52,7 @@ public class SessionsRepository implements SessionsDataSource {
     public Maybe<Session> find(int sessionId, String languageId) {
         if (hasCacheSession(sessionId)) {
             return Maybe.create(emitter -> {
-                try {
-                    emitter.onSuccess(cachedSessions.get(sessionId));
-                } catch (Exception e) {
-                    emitter.onError(e);
-                }
+                emitter.onSuccess(cachedSessions.get(sessionId));
             });
         }
 


### PR DESCRIPTION

## Issue
- None

## Overview (Required)
- remove unnecessary try catch in SingleOnSubscribe.subscribe() and MaybeOnSubscribe.subscribe(), because MaybeCreate and SingleCreate call onError() when Exception throws in subscribe().

```
public final class SingleCreate<T> extends Single<T> {

    final SingleOnSubscribe<T> source;

    public SingleCreate(SingleOnSubscribe<T> source) {
        this.source = source;
    }

    @Override
    protected void subscribeActual(SingleObserver<? super T> s) {
        Emitter<T> parent = new Emitter<T>(s);
        s.onSubscribe(parent);

        try {
            source.subscribe(parent);
        } catch (Throwable ex) {
            Exceptions.throwIfFatal(ex);
            parent.onError(ex);
        }
    }
    ...
}
```

