### PR TITLE
Fix move to correct session's detail from notifications

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/receiver/NotificationReceiver.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/receiver/NotificationReceiver.java
@@ -80,7 +80,7 @@ public class NotificationReceiver extends BroadcastReceiver {
         int priority = headsUp ? NotificationCompat.PRIORITY_HIGH : NotificationCompat.PRIORITY_DEFAULT;
         Intent openIntent = SessionDetailActivity.createIntent(context, sessionId);
         openIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
-        PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, openIntent, 0);
+        PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, openIntent, PendingIntent.FLAG_UPDATE_CURRENT);
         NotificationCompat.Builder builder = new NotificationCompat.Builder(context)
                 .setTicker(title)
                 .setContentTitle(title)


### PR DESCRIPTION
## Issue
Session A's notification notified, tap it and move to A's detail.
Next, session B's notification notified, tap it and move to A, not B.

## Overview (Required)
- Extra data of PendingIntent used in notification was not updated.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
