### PR TITLE
Fix stetho interceptor

### DIFF
--- a/app/src/debug/java/io/github/droidkaigi/confsched2017/di/HttpClientModule.java
+++ b/app/src/debug/java/io/github/droidkaigi/confsched2017/di/HttpClientModule.java
@@ -28,7 +28,7 @@ public class HttpClientModule {
         Cache cache = new Cache(cacheDir, MAX_CACHE_SIZE);
 
         OkHttpClient.Builder c = new OkHttpClient.Builder().cache(cache).addInterceptor(interceptor)
-                .addInterceptor(new StethoInterceptor());
+                .addNetworkInterceptor(new StethoInterceptor());
         return c.build();
     }
 }


### PR DESCRIPTION
## Issue
-

## Overview (Required)
- When I open stetho, GitHub API fails.
- Stetho doc says to use `addNetworkInterceptor`.

## Links
- http://facebook.github.io/stetho/#integrations

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
