### PR TITLE
execute pending transaction before the next fragment transaction starts

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/MainActivity.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/MainActivity.java
@@ -109,6 +109,11 @@ public class MainActivity extends BaseActivity {
         } else {
             ft.add(R.id.content_view, fragment, tag);
         }
-        ft.setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE).commit();
+        ft.setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
+                .commit();
+
+        // NOTE: When this method is called by user's continuous hitting at the same time,
+        // transactions are queued, so necessary to reflect commit instantly before next transaction starts.
+        manager.executePendingTransactions();
     }
 }


### PR DESCRIPTION
## Issue
- #235 

## Overview (Required)
-  When I hit the BottomNavigationView Item continuously at the same time, it would often cause this below. (screenshot)

## Tasks
- [x] execute the transaction at once before starting the new transactions. 

## Links
- https://developer.android.com/reference/android/app/FragmentManager.html
- http://qiita.com/tomoima525/items/d10fda955a97c265f338

## Screenshot
Before | After
:--: | :--:
<img src="https://cloud.githubusercontent.com/assets/6552589/22745578/700f50f4-ee64-11e6-9f33-6befcc7bcc3e.png" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/6552589/22747137/7e4d4c34-ee69-11e6-8668-8befc72344fe.png" width="300" />
