### PR TITLE
Highlight ongoing sessions

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/model/Session.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/model/Session.java
@@ -109,6 +109,10 @@ public class Session {
         return type.toString().equals(this.type);
     }
 
+    public boolean isLiveAt(Date when) {
+        return stime.before(when) && etime.after(when);
+    }
+
     @Override
     public boolean equals(Object o) {
         return o instanceof Session && ((Session) o).id == id || super.equals(o);

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/model/Session.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/model/Session.java
@@ -6,7 +6,6 @@ import com.github.gfx.android.orma.annotation.Column;
 import com.github.gfx.android.orma.annotation.PrimaryKey;
 import com.github.gfx.android.orma.annotation.Table;
 
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import java.util.Date;
@@ -87,26 +86,21 @@ public class Session {
     private enum Type {
         CEREMONY, SESSION, BREAK;
 
-        @Override
-        public String toString() {
-            return super.toString().toLowerCase();
+        boolean matches(String type) {
+            return name().equalsIgnoreCase(type);
         }
     }
 
     public boolean isSession() {
-        return isSameType(Type.SESSION);
+        return Type.SESSION.matches(type);
     }
 
     public boolean isCeremony() {
-        return isSameType(Type.CEREMONY);
+        return Type.CEREMONY.matches(type);
     }
 
     public boolean isBreak() {
-        return isSameType(Type.BREAK);
-    }
-
-    private boolean isSameType(@NonNull Type type) {
-        return type.toString().equals(this.type);
+        return Type.BREAK.matches(type);
     }
 
     public boolean isLiveAt(Date when) {

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/SessionViewModel.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/SessionViewModel.java
@@ -87,11 +87,10 @@ public class SessionViewModel extends BaseObservable implements ViewModel {
             this.normalSessionItemVisibility = View.GONE;
         } else {
             this.isClickable = true;
-            this.backgroundResId = R.drawable.clickable_white;
+            this.backgroundResId = session.isLiveAt(new Date())? R.drawable.clickable_purple : R.drawable.clickable_white;
             this.topicColorResId = TopicColor.from(session.topic).middleColorResId;
             this.normalSessionItemVisibility = View.VISIBLE;
         }
-
     }
 
     private SessionViewModel(int rowSpan, int colSpan) {

--- a/app/src/main/res/drawable-v21/clickable_purple.xml
+++ b/app/src/main/res/drawable-v21/clickable_purple.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+        android:color="@color/black_alpha_12"
+        >
+
+    <item
+            android:id="@android:id/mask"
+            android:drawable="@android:color/white"
+            />
+
+    <item android:drawable="@color/purple_alpha_15" />
+
+</ripple>

--- a/app/src/main/res/drawable/clickable_purple.xml
+++ b/app/src/main/res/drawable/clickable_purple.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:state_pressed="false">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/purple_alpha_15" />
+        </shape>
+    </item>
+
+    <item android:state_pressed="true">
+        <layer-list>
+            <item>
+                <shape android:shape="rectangle">
+                    <solid android:color="@color/purple_alpha_15" />
+                </shape>
+            </item>
+            <item>
+                <shape android:shape="rectangle">
+                    <solid android:color="@color/black_alpha_12" />
+                </shape>
+            </item>
+        </layer-list>
+    </item>
+
+</selector>


### PR DESCRIPTION
## Issue
- #161

## Overview (Required)
- Highlight ongoing sessions. It checks every session with `new Date()` but I don't have any good pattern for this and implemented such roughly as-is.
- It seems `Session.Type#toString()` is overriden just for `equals` check.  
If `Session.type` is `Type type`, `Session#isBreak()` will be `type == Type.BREAK`.
idk why `Session.type` is not `Type` (im not familiar with orma, adapting enum brings complexity?) so just make `Type` to have its own equality method using `name().equalsIgnoreCase()`. I will revert this change as you like (eg. json should strictly declare lowercase for `type` key. this change will be breaking).

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/1487505/22748744/6515d7f4-ee6e-11e6-839a-72b1c89b85ba.png" width="300" />
