### PR TITLE
Fix session language decision in SessionDetailViewModel

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/SessionDetailViewModel.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/SessionDetailViewModel.java
@@ -85,7 +85,7 @@ public class SessionDetailViewModel extends BaseObservable implements ViewModel 
         this.dashVideoIconVisibility = session.movieUrl != null && session.movieDashUrl != null ? View.VISIBLE : View.GONE;
         this.roomVisibility = session.room != null ? View.VISIBLE : View.GONE;
         this.topicVisibility = session.topic != null ? View.VISIBLE : View.GONE;
-        this.languageResId = session.lang != null ? decideLanguageResId(session.lang.toUpperCase()) : R.string.lang_en;
+        this.languageResId = session.lang != null ? decideLanguageResId(session.lang.toLowerCase()) : R.string.lang_en;
     }
 
     public Completable loadSession(int sessionId) {


### PR DESCRIPTION
## Issue
- Session language in detail page is always English #243

## Overview (Required)
- Change session id letter case from upper to small, because `LocaleUtil` constant value is lower case.

## Links
- https://github.com/DroidKaigi/conference-app-2017/blob/master/app/src/main/java/io/github/droidkaigi/confsched2017/util/LocaleUtil.java

## Screenshot
Before | After
:--: | :--:
<img src="https://cloud.githubusercontent.com/assets/7804631/22764434/0d2b4070-eeae-11e6-81e5-87ceceb5f384.png" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/7804631/22764541/a09a87c6-eeae-11e6-9539-051b84414b61.png" width="300" />

