### PR TITLE
Apply style to Toolbar of session detail screen to change back button color.

### DIFF
--- a/app/src/main/res/layout/fragment_session_detail.xml
+++ b/app/src/main/res/layout/fragment_session_detail.xml
@@ -82,7 +82,6 @@
                         android:layout_height="?attr/actionBarSize"
                         android:background="?attr/selectableItemBackground"
                         style="@style/BaseToolbar"
-                        app:contentInsetStartWithNavigation="0dp"
                         app:layout_collapseMode="pin"
                         />
 

--- a/app/src/main/res/layout/fragment_session_detail.xml
+++ b/app/src/main/res/layout/fragment_session_detail.xml
@@ -81,6 +81,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="?attr/actionBarSize"
                         android:background="?attr/selectableItemBackground"
+                        style="@style/BaseToolbar"
                         app:contentInsetStartWithNavigation="0dp"
                         app:layout_collapseMode="pin"
                         />


### PR DESCRIPTION
## Issue
![_2017_02_09_12_33](https://cloud.githubusercontent.com/assets/10704349/22768244/12ad1f58-eec4-11e6-89b8-0068147eef33.png)

In session detail screen, back key color is not white.

## Overview (Required)
- Apply theme to Toolbar to set standard colors of this app.

## Screenshot
Before | After
:--: | :--:
<img src="https://cloud.githubusercontent.com/assets/10704349/22769579/f056766c-eecc-11e6-9c3e-f7b7ccb55bb0.png" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/10704349/22769581/f1d4a036-eecc-11e6-9202-4fd87ec65125.png" width="300" />
<img src="https://cloud.githubusercontent.com/assets/10704349/22768312/94c5beaa-eec4-11e6-81fd-6ef4eb1dfa12.png" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/10704349/22768315/97f8928c-eec4-11e6-9487-d57ee7584584.png" width="300" />
<img src="https://cloud.githubusercontent.com/assets/10704349/22769588/fd7950a8-eecc-11e6-8f2e-76a3831d0f61.png" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/10704349/22769593/fd97d712-eecc-11e6-8f1b-c2ee6a53a937.png" width="300" />
<img src="https://cloud.githubusercontent.com/assets/10704349/22769587/fd794aa4-eecc-11e6-8891-3428364dc295.png" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/10704349/22769594/fd993d82-eecc-11e6-9dd7-ef5e967f71bb.png" width="300" />
<img src="https://cloud.githubusercontent.com/assets/10704349/22769589/fd796afc-eecc-11e6-8c8f-a863665828dc.png" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/10704349/22769595/fd9976c6-eecc-11e6-9ee9-fbf4d803e812.png" width="300" />
<img src="https://cloud.githubusercontent.com/assets/10704349/22769591/fd7d4bae-eecc-11e6-87a8-79d82f5580e1.png" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/10704349/22769596/fda037a4-eecc-11e6-9d8d-60c452963f51.png" width="300" />
<img src="https://cloud.githubusercontent.com/assets/10704349/22769592/fd949660-eecc-11e6-89fd-0ed9f443d097.png" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/10704349/22769597/fda300ba-eecc-11e6-9ada-d903a8bf36dc.png" width="300" />


