### PR TITLE
Use application context for sensor

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/BaseActivity.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/BaseActivity.java
@@ -48,7 +48,7 @@ public abstract class BaseActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         debot = Debot.getInstance();
-        debot.allowShake(this);
+        debot.allowShake(getApplicationContext());
     }
 
     @Override


### PR DESCRIPTION
## Issue
- #246 

## Overview (Required)
- Leakcanary reports leaking Activity in Debot. It seems SensorManager might being hold Activity if created with `activityContext.getSystemService()` 
 https://github.com/tomoima525/debot/blob/master/debot/src/main/java/com/tomoima/debot/Debot.java#L57 
I think it can be solved with some ways.
1. Debot uses `context.getApplicationContext().getSystemService()`
2. Passing `getApplicationContext()` by ourselves.
3. Move calling `debot#allowShake()` to `onResume()`
4. AOSP fix this.

I did quick fix with 2 and not detected leak currently. But not much tested, would you check this?

