### PR TITLE
Add notification test mode

### DIFF
--- a/app/src/debug/java/io/github/droidkaigi/confsched2017/debug/NotificationStrategy.java
+++ b/app/src/debug/java/io/github/droidkaigi/confsched2017/debug/NotificationStrategy.java
@@ -1,0 +1,31 @@
+package io.github.droidkaigi.confsched2017.debug;
+
+import com.tomoima.debot.strategy.DebotStrategy;
+
+import android.app.Activity;
+import android.support.annotation.NonNull;
+import android.widget.Toast;
+
+import javax.inject.Inject;
+
+import io.github.droidkaigi.confsched2017.pref.DefaultPrefs;
+
+public class NotificationStrategy extends DebotStrategy {
+
+    @Inject
+    NotificationStrategy() {
+
+    }
+
+    @Override
+    public void startAction(@NonNull Activity activity) {
+        DefaultPrefs prefs = DefaultPrefs.get(activity);
+        if (prefs.getNotificationTestFlag()) {
+            prefs.setNotificationTestFlag(false);
+            Toast.makeText(activity, "Notification will be displayed 10 minutes before sessions", Toast.LENGTH_SHORT).show();
+        } else {
+            prefs.setNotificationTestFlag(true);
+            Toast.makeText(activity, "Notification will be displayed after 5 seconds", Toast.LENGTH_SHORT).show();
+        }
+    }
+}

--- a/app/src/debug/java/io/github/droidkaigi/confsched2017/debug/NotificationStrategy.java
+++ b/app/src/debug/java/io/github/droidkaigi/confsched2017/debug/NotificationStrategy.java
@@ -8,6 +8,7 @@ import android.widget.Toast;
 
 import javax.inject.Inject;
 
+import io.github.droidkaigi.confsched2017.MainApplication;
 import io.github.droidkaigi.confsched2017.pref.DefaultPrefs;
 
 public class NotificationStrategy extends DebotStrategy {
@@ -27,5 +28,8 @@ public class NotificationStrategy extends DebotStrategy {
             prefs.setNotificationTestFlag(true);
             Toast.makeText(activity, "Notification will be displayed after 5 seconds", Toast.LENGTH_SHORT).show();
         }
+
+        MainApplication application = (MainApplication) activity.getApplication();
+        application.initDebot();
     }
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/MainApplication.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/MainApplication.java
@@ -54,7 +54,7 @@ public class MainApplication extends Application {
 
         DebotStrategyBuilder builder = new DebotStrategyBuilder.Builder(this)
                 .registerMenu("Clear cache", clearCache)
-                .registerMenu("Test notification", notificationStrategy)
+                .registerMenu("Notification test ON/OFF", notificationStrategy)
                 .build();
         DebotConfigurator.configureWithCustomizedMenu(this, builder.getStrategyList());
     }

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/MainApplication.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/MainApplication.java
@@ -17,6 +17,7 @@ import io.github.droidkaigi.confsched2017.di.AppComponent;
 import io.github.droidkaigi.confsched2017.di.AppModule;
 import io.github.droidkaigi.confsched2017.di.DaggerAppComponent;
 import io.github.droidkaigi.confsched2017.log.CrashLogTree;
+import io.github.droidkaigi.confsched2017.pref.DefaultPrefs;
 import timber.log.Timber;
 import uk.co.chrisjenx.calligraphy.CalligraphyConfig;
 
@@ -52,11 +53,7 @@ public class MainApplication extends Application {
         }
         Timber.plant(new CrashLogTree()); // TODO initialize Firebase before this line
 
-        DebotStrategyBuilder builder = new DebotStrategyBuilder.Builder(this)
-                .registerMenu("Clear cache", clearCache)
-                .registerMenu("Notification test ON/OFF", notificationStrategy)
-                .build();
-        DebotConfigurator.configureWithCustomizedMenu(this, builder.getStrategyList());
+        initDebot();
     }
 
     private void initCalligraphy() {
@@ -72,5 +69,20 @@ public class MainApplication extends Application {
             return;
         }
         LeakCanary.install(this);
+    }
+
+    public void initDebot() {
+        DefaultPrefs prefs = DefaultPrefs.get(this);
+        String notificationTestTitle;
+        if (prefs.getNotificationTestFlag()) {
+            notificationTestTitle = "Notification test OFF";
+        } else {
+            notificationTestTitle = "Notification test ON";
+        }
+        DebotStrategyBuilder builder = new DebotStrategyBuilder.Builder(this)
+                .registerMenu("Clear cache", clearCache)
+                .registerMenu(notificationTestTitle, notificationStrategy)
+                .build();
+        DebotConfigurator.configureWithCustomizedMenu(this, builder.getStrategyList());
     }
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/MainApplication.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/MainApplication.java
@@ -11,6 +11,7 @@ import android.support.annotation.NonNull;
 import javax.inject.Inject;
 
 import io.github.droidkaigi.confsched2017.debug.ClearCache;
+import io.github.droidkaigi.confsched2017.debug.NotificationStrategy;
 import io.github.droidkaigi.confsched2017.di.AndroidModule;
 import io.github.droidkaigi.confsched2017.di.AppComponent;
 import io.github.droidkaigi.confsched2017.di.AppModule;
@@ -25,6 +26,9 @@ public class MainApplication extends Application {
 
     @Inject
     ClearCache clearCache;
+
+    @Inject
+    NotificationStrategy notificationStrategy;
 
     @NonNull
     public AppComponent getComponent() {
@@ -50,6 +54,7 @@ public class MainApplication extends Application {
 
         DebotStrategyBuilder builder = new DebotStrategyBuilder.Builder(this)
                 .registerMenu("Clear cache", clearCache)
+                .registerMenu("Test notification", notificationStrategy)
                 .build();
         DebotConfigurator.configureWithCustomizedMenu(this, builder.getStrategyList());
     }

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/pref/DefaultPrefsSchema.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/pref/DefaultPrefsSchema.java
@@ -18,4 +18,6 @@ public interface DefaultPrefsSchema {
     @Key(name = "show_local_time")
     boolean showLocalTimeFlag = false;
 
+    @Key(name = "notification_test_setting")
+    boolean notificationTestFlag = false;
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/util/AlarmUtil.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/util/AlarmUtil.java
@@ -12,6 +12,7 @@ import java.util.concurrent.TimeUnit;
 
 import io.github.droidkaigi.confsched2017.R;
 import io.github.droidkaigi.confsched2017.model.Session;
+import io.github.droidkaigi.confsched2017.pref.DefaultPrefs;
 import io.github.droidkaigi.confsched2017.receiver.NotificationReceiver;
 
 public class AlarmUtil {
@@ -20,8 +21,12 @@ public class AlarmUtil {
 
     public static void registerAlarm(@NonNull Context context, @NonNull Session session) {
         long time = session.stime.getTime() - REMIND_DURATION_MINUTES_FOR_START;
-        // To develop notification, please uncomment this line
-        //time = System.currentTimeMillis() + 5000;
+
+        DefaultPrefs prefs = DefaultPrefs.get(context);
+        if (prefs.getNotificationTestFlag()) {
+            time = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(5);
+        }
+
         if (System.currentTimeMillis() < time) {
             AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {

--- a/app/src/release/java/io/github/droidkaigi/confsched2017/debug/NotificationStrategy.java
+++ b/app/src/release/java/io/github/droidkaigi/confsched2017/debug/NotificationStrategy.java
@@ -1,0 +1,21 @@
+package io.github.droidkaigi.confsched2017.debug;
+
+import com.tomoima.debot.strategy.DebotStrategy;
+
+import android.app.Activity;
+import android.support.annotation.NonNull;
+
+import javax.inject.Inject;
+
+
+public class NotificationStrategy extends DebotStrategy {
+
+    @Inject
+    public NotificationStrategy() {
+    }
+
+    @Override
+    public void startAction(@NonNull Activity activity) {
+        // Do nothing
+    }
+}


### PR DESCRIPTION
## Issue
-

## Overview (Required)
- Add notification test mode using debot
  - If notification test mode is enabled, notifications will be displayed 5 sec after FAB check actions.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | ![device-2017-02-09-175610](https://cloud.githubusercontent.com/assets/900756/22775922/19dd5e6e-eef1-11e6-8ac2-3cd4fdf77a03.png)

