### PR TITLE
Add touch feedback to information icons with ripple

### DIFF
--- a/app/src/main/res/layout/fragment_information.xml
+++ b/app/src/main/res/layout/fragment_information.xml
@@ -67,6 +67,7 @@
                             android:id="@+id/img_twitter"
                             android:layout_width="@dimen/info_social_icon_size"
                             android:layout_height="@dimen/info_social_icon_size"
+                            android:background="?attr/selectableItemBackgroundBorderless"
                             android:onClick="@{viewModel::onClickTwitter}"
                             app:srcCompat="@drawable/ic_twitter_36_vector"
                             />
@@ -77,6 +78,7 @@
                             android:layout_height="@dimen/info_social_icon_size"
                             android:layout_marginLeft="@dimen/info_social_icon_margin"
                             android:layout_marginStart="@dimen/info_social_icon_margin"
+                            android:background="?attr/selectableItemBackgroundBorderless"
                             android:onClick="@{viewModel::onClickFacebook}"
                             app:srcCompat="@drawable/ic_facebook_36_vector"
                             />
@@ -87,6 +89,7 @@
                             android:layout_height="@dimen/info_social_icon_size"
                             android:layout_marginLeft="@dimen/info_social_icon_margin"
                             android:layout_marginStart="@dimen/info_social_icon_margin"
+                            android:background="?attr/selectableItemBackgroundBorderless"
                             android:onClick="@{viewModel::onClickGitHub}"
                             app:srcCompat="@drawable/ic_github_36_vector"
                             />
@@ -97,6 +100,7 @@
                             android:layout_height="@dimen/info_social_icon_size"
                             android:layout_marginLeft="@dimen/info_social_icon_margin"
                             android:layout_marginStart="@dimen/info_social_icon_margin"
+                            android:background="?attr/selectableItemBackgroundBorderless"
                             android:onClick="@{viewModel::onClickDroidKaigiWeb}"
                             android:src="@drawable/ic_droidkaigi"
                             />
@@ -107,6 +111,7 @@
                             android:layout_height="@dimen/info_social_icon_size"
                             android:layout_marginLeft="@dimen/info_social_icon_margin"
                             android:layout_marginStart="@dimen/info_social_icon_margin"
+                            android:background="?attr/selectableItemBackgroundBorderless"
                             android:onClick="@{viewModel::onClickYouTube}"
                             app:srcCompat="@drawable/ic_youtube_36_vector"
                             />


### PR DESCRIPTION
## Issue
none

## Overview (Required)
According to the material design guidelines, view that can be clicked need touch feedback with ripple effect.
(In pre-lollipop, this setting is ignored.)

## Links
https://material.io/guidelines/motion/choreography.html#choreography-radial-reaction

## Screenshot
Before | After
:--: | :--:
<img src="https://cloud.githubusercontent.com/assets/11440952/22790186/b46370d6-ef28-11e6-9b67-5450ccda9d30.gif" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/11440952/22790205/c396385e-ef28-11e6-9f36-92dc05aab5d0.gif" width="300" />