### PR TITLE
Refactoring contributors list

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/customview/ArrayRecyclerAdapter.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/customview/ArrayRecyclerAdapter.java
@@ -8,17 +8,22 @@ import android.support.v7.widget.RecyclerView;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 
 public abstract class ArrayRecyclerAdapter<T, VH extends RecyclerView.ViewHolder>
         extends RecyclerView.Adapter<VH> implements Iterable<T> {
 
-    protected final ArrayList<T> list;
+    protected final List<T> list;
 
     final Context context;
 
     public ArrayRecyclerAdapter(@NonNull Context context) {
+        this(context, new ArrayList<>());
+    }
+
+    public ArrayRecyclerAdapter(@NonNull Context context, @NonNull List<T> list) {
         this.context = context;
-        this.list = new ArrayList<>();
+        this.list = list;
     }
 
     @UiThread

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/ContributorsFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/ContributorsFragment.java
@@ -143,7 +143,7 @@ public class ContributorsFragment extends BaseFragment implements ContributorsVi
                 @Override
                 public void onItemRangeMoved(ObservableList<ContributorViewModel> contributorViewModels, int i, int i1,
                         int i2) {
-                    notifyDataSetChanged();
+                    notifyItemMoved(i, i1);
                 }
 
                 @Override

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/ContributorsFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/ContributorsFragment.java
@@ -4,6 +4,7 @@ import com.annimon.stream.Optional;
 
 import android.content.Context;
 import android.content.Intent;
+import android.databinding.ObservableList;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -83,16 +84,12 @@ public class ContributorsFragment extends BaseFragment implements ContributorsVi
     }
 
     private void initView() {
-        adapter = new Adapter(getContext());
+        adapter = new Adapter(getContext(), viewModel.getContributorViewModels());
         binding.recyclerView.setAdapter(adapter);
         binding.recyclerView.setLayoutManager(new GridLayoutManager(getContext(), COLUMN_COUNT));
     }
 
     private void renderContributors(List<ContributorViewModel> contributors) {
-        adapter.clear();
-        adapter.addAll(contributors);
-        adapter.notifyDataSetChanged();
-
         Optional.ofNullable(getActivity())
                 .select(AppCompatActivity.class)
                 .map(AppCompatActivity::getSupportActionBar)
@@ -124,8 +121,36 @@ public class ContributorsFragment extends BaseFragment implements ContributorsVi
     private static class Adapter
             extends ArrayRecyclerAdapter<ContributorViewModel, BindingHolder<ViewContributorCellBinding>> {
 
-        public Adapter(@NonNull Context context) {
-            super(context);
+        public Adapter(@NonNull Context context, @NonNull ObservableList<ContributorViewModel> list) {
+            super(context, list);
+
+            list.addOnListChangedCallback(new ObservableList.OnListChangedCallback<ObservableList<ContributorViewModel>>() {
+                @Override
+                public void onChanged(ObservableList<ContributorViewModel> contributorViewModels) {
+                    notifyDataSetChanged();
+                }
+
+                @Override
+                public void onItemRangeChanged(ObservableList<ContributorViewModel> contributorViewModels, int i, int i1) {
+                    notifyDataSetChanged();
+                }
+
+                @Override
+                public void onItemRangeInserted(ObservableList<ContributorViewModel> contributorViewModels, int i, int i1) {
+                    notifyDataSetChanged();
+                }
+
+                @Override
+                public void onItemRangeMoved(ObservableList<ContributorViewModel> contributorViewModels, int i, int i1,
+                        int i2) {
+                    notifyDataSetChanged();
+                }
+
+                @Override
+                public void onItemRangeRemoved(ObservableList<ContributorViewModel> contributorViewModels, int i, int i1) {
+                    notifyDataSetChanged();
+                }
+            });
         }
 
         @Override

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/ContributorsFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/ContributorsFragment.java
@@ -132,12 +132,12 @@ public class ContributorsFragment extends BaseFragment implements ContributorsVi
 
                 @Override
                 public void onItemRangeChanged(ObservableList<ContributorViewModel> contributorViewModels, int i, int i1) {
-                    notifyDataSetChanged();
+                    notifyItemRangeChanged(i, i1);
                 }
 
                 @Override
                 public void onItemRangeInserted(ObservableList<ContributorViewModel> contributorViewModels, int i, int i1) {
-                    notifyDataSetChanged();
+                    notifyItemRangeInserted(i, i1);
                 }
 
                 @Override
@@ -148,7 +148,7 @@ public class ContributorsFragment extends BaseFragment implements ContributorsVi
 
                 @Override
                 public void onItemRangeRemoved(ObservableList<ContributorViewModel> contributorViewModels, int i, int i1) {
-                    notifyDataSetChanged();
+                    notifyItemRangeRemoved(i, i1);
                 }
             });
         }


### PR DESCRIPTION
## Issue
-

## Overview (Required)
- This PR demonstrates the way to bind RecyclerView Adapter to `ObservableList`.
- Concept
  - Fragment's role is just to set `ObservableList` to adapter at first. After set, fragment does nothing.
  - In adapter's constructor, it add callback to `ObservableList`. In the callback, notify methods of RecyclerView are executed.
  - `ContributorsViewModel` only add or remove items to `ObservableList`.
- Since this PR is just a suggestion (not strong opinion), it is up to you whether to merge.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
