### PR TITLE
Update Constraint Layout to beta 5

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -182,7 +182,7 @@ dependencies {
     compile "com.android.support:customtabs:${support_lib_version}"
     compile "com.android.support:support-vector-drawable:${support_lib_version}"
     compile "com.android.support:animated-vector-drawable:${support_lib_version}"
-    compile 'com.android.support.constraint:constraint-layout:1.0.0-beta4'
+    compile 'com.android.support.constraint:constraint-layout:1.0.0-beta5'
 
     // Firebase(analytics, crash report)
     compile 'com.google.firebase:firebase-core:10.0.1'

--- a/circle.yml
+++ b/circle.yml
@@ -14,8 +14,8 @@ dependencies:
     - echo -e "8933bad161af4178b1185d1a37fbf41ea5269c55" > $ANDROID_HOME/licenses/android-sdk-license
     - echo -e "84831b9409646a918e30573bab4c9c91346d8abd" > $ANDROID_HOME/licenses/android-sdk-preview-license
     - $ANDROID_HOME/tools/bin/sdkmanager "platform-tools" "extras;android;m2repository" "extras;google;m2repository"
-    - $ANDROID_HOME/tools/bin/sdkmanager "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.0-beta4"
-    - $ANDROID_HOME/tools/bin/sdkmanager "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta4"
+    - $ANDROID_HOME/tools/bin/sdkmanager "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.0-beta5"
+    - $ANDROID_HOME/tools/bin/sdkmanager "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta5"
   override:
     - ./gradlew app:dependencies
 


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- Update constraint layout to beta 5 released today

## Links
- https://sites.google.com/a/android.com/tools/recent/constraintlayoutbeta5isnowavailable

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
