### PR TITLE
Use the order of enum as topic id.

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/model/Topic.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/model/Topic.java
@@ -10,20 +10,6 @@ import com.google.gson.annotations.SerializedName;
 @Table
 public class Topic {
 
-    public static final int ID_PRODUCTIVITY_AND_TOOLING = 1;
-
-    public static final int ID_ARCHITECTURE_AND_DEVELOPMENT_PROCESS_METHODOLOGY = 2;
-
-    public static final int ID_HARDWARE = 3;
-
-    public static final int ID_UI_AND_DESIGN = 4;
-
-    public static final int ID_QUALITY_AND_SUSTAINABILITY = 5;
-
-    public static final int ID_PLATFORM = 6;
-
-    public static final int ID_OTHER = 7;
-
     @PrimaryKey(auto = false)
     @Column(indexed = true)
     @SerializedName("id")

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/TopicColor.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/TopicColor.java
@@ -3,6 +3,7 @@ package io.github.droidkaigi.confsched2017.viewmodel;
 import android.support.annotation.ColorRes;
 import android.support.annotation.Nullable;
 import android.support.annotation.StyleRes;
+import android.support.annotation.VisibleForTesting;
 
 import io.github.droidkaigi.confsched2017.R;
 import io.github.droidkaigi.confsched2017.model.Topic;
@@ -33,7 +34,7 @@ enum TopicColor {
     NONE(0, R.color.purple_alpha_15, R.color.purple_alpha_50,
             R.color.purple, R.style.AppTheme_NoActionBar_Purple);
 
-    private int topicId;
+    @VisibleForTesting int topicId;
 
     @ColorRes
     public int paleColorResId;

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/TopicColor.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/TopicColor.java
@@ -8,30 +8,33 @@ import android.support.annotation.VisibleForTesting;
 import io.github.droidkaigi.confsched2017.R;
 import io.github.droidkaigi.confsched2017.model.Topic;
 
+/**
+ * Topic ID corresponds to the order of enum.
+ */
 enum TopicColor {
 
-    PRODUCTIVITY_AND_TOOLING(1, R.color.light_green_alpha_15, R.color.light_green_alpha_50,
-            R.color.light_green, R.style.AppTheme_NoActionBar_LightGreen),
-
-    ARCHITECTURE_AND_DEVELOPMENT_PROCESS_METHODOLOGY(2, R.color.yellow_alpha_15, R.color.yellow_alpha_50,
-            R.color.yellow, R.style.AppTheme_NoActionBar_Yellow),
-
-    HARDWARE(3, R.color.red_alpha_15, R.color.red_alpha_50,
-            R.color.red, R.style.AppTheme_NoActionBar_Red),
-
-    UI_AND_DESIGN(4, R.color.blue_alpha_15, R.color.blue_alpha_50,
-            R.color.blue, R.style.AppTheme_NoActionBar_Blue),
-
-    QUALITY_AND_SUSTAINABILITY(5, R.color.light_blue_alpha_15, R.color.light_blue_alpha_50,
-            R.color.light_blue, R.style.AppTheme_NoActionBar_LightBlue),
-
-    PLATFORM(6, R.color.pink_alpha_15, R.color.pink_alpha_50,
-            R.color.pink, R.style.AppTheme_NoActionBar_Pink),
-
-    OTHER(7, R.color.purple_alpha_15, R.color.purple_alpha_50,
+    NONE(R.color.purple_alpha_15, R.color.purple_alpha_50,
             R.color.purple, R.style.AppTheme_NoActionBar_Purple),
 
-    NONE(0, R.color.purple_alpha_15, R.color.purple_alpha_50,
+    PRODUCTIVITY_AND_TOOLING(R.color.light_green_alpha_15, R.color.light_green_alpha_50,
+            R.color.light_green, R.style.AppTheme_NoActionBar_LightGreen),
+
+    ARCHITECTURE_AND_DEVELOPMENT_PROCESS_METHODOLOGY(R.color.yellow_alpha_15, R.color.yellow_alpha_50,
+            R.color.yellow, R.style.AppTheme_NoActionBar_Yellow),
+
+    HARDWARE(R.color.red_alpha_15, R.color.red_alpha_50,
+            R.color.red, R.style.AppTheme_NoActionBar_Red),
+
+    UI_AND_DESIGN(R.color.blue_alpha_15, R.color.blue_alpha_50,
+            R.color.blue, R.style.AppTheme_NoActionBar_Blue),
+
+    QUALITY_AND_SUSTAINABILITY(R.color.light_blue_alpha_15, R.color.light_blue_alpha_50,
+            R.color.light_blue, R.style.AppTheme_NoActionBar_LightBlue),
+
+    PLATFORM(R.color.pink_alpha_15, R.color.pink_alpha_50,
+            R.color.pink, R.style.AppTheme_NoActionBar_Pink),
+
+    OTHER(R.color.purple_alpha_15, R.color.purple_alpha_50,
             R.color.purple, R.style.AppTheme_NoActionBar_Purple);
 
     @VisibleForTesting int topicId;
@@ -48,9 +51,9 @@ enum TopicColor {
     @StyleRes
     public int themeId;
 
-    TopicColor(int topicId, @ColorRes int paleColorResId, @ColorRes int middleColorResId,
+    TopicColor(@ColorRes int paleColorResId, @ColorRes int middleColorResId,
             @ColorRes int vividColorResId, @StyleRes int themeId) {
-        this.topicId = topicId;
+        this.topicId = ordinal();
         this.paleColorResId = paleColorResId;
         this.middleColorResId = middleColorResId;
         this.vividColorResId = vividColorResId;
@@ -60,23 +63,13 @@ enum TopicColor {
     public static TopicColor from(@Nullable Topic topic) {
         if (topic == null) {
             return NONE;
-        } else if (PRODUCTIVITY_AND_TOOLING.topicId == topic.id) {
-            return PRODUCTIVITY_AND_TOOLING;
-        } else if (ARCHITECTURE_AND_DEVELOPMENT_PROCESS_METHODOLOGY.topicId == topic.id) {
-            return ARCHITECTURE_AND_DEVELOPMENT_PROCESS_METHODOLOGY;
-        } else if (HARDWARE.topicId == topic.id) {
-            return HARDWARE;
-        } else if (UI_AND_DESIGN.topicId == topic.id) {
-            return UI_AND_DESIGN;
-        } else if (QUALITY_AND_SUSTAINABILITY.topicId == topic.id) {
-            return QUALITY_AND_SUSTAINABILITY;
-        } else if (PLATFORM.topicId == topic.id) {
-            return PLATFORM;
-        } else if (OTHER.topicId == topic.id) {
-            return OTHER;
-        } else {
+        }
+        if (topic.id < 0) {
             return NONE;
         }
+        if (topic.id >= TopicColor.values().length) {
+            return NONE;
+        }
+        return TopicColor.values()[topic.id];
     }
-
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/TopicColor.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/TopicColor.java
@@ -3,7 +3,6 @@ package io.github.droidkaigi.confsched2017.viewmodel;
 import android.support.annotation.ColorRes;
 import android.support.annotation.Nullable;
 import android.support.annotation.StyleRes;
-import android.support.annotation.VisibleForTesting;
 
 import io.github.droidkaigi.confsched2017.R;
 import io.github.droidkaigi.confsched2017.model.Topic;
@@ -37,8 +36,6 @@ enum TopicColor {
     OTHER(R.color.purple_alpha_15, R.color.purple_alpha_50,
             R.color.purple, R.style.AppTheme_NoActionBar_Purple);
 
-    @VisibleForTesting int topicId;
-
     @ColorRes
     public int paleColorResId;
 
@@ -53,7 +50,6 @@ enum TopicColor {
 
     TopicColor(@ColorRes int paleColorResId, @ColorRes int middleColorResId,
             @ColorRes int vividColorResId, @StyleRes int themeId) {
-        this.topicId = ordinal();
         this.paleColorResId = paleColorResId;
         this.middleColorResId = middleColorResId;
         this.vividColorResId = vividColorResId;

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/TopicColor.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/TopicColor.java
@@ -9,6 +9,8 @@ import io.github.droidkaigi.confsched2017.model.Topic;
 
 /**
  * Topic ID corresponds to the order of enum.
+ * TODO There is not the specification document about topic id yet.
+ * But you can see raw json data https://droidkaigi.github.io/2017/sessions.json
  */
 enum TopicColor {
 

--- a/app/src/test/java/io/github/droidkaigi/confsched2017/viewmodel/TopicColorTest.kt
+++ b/app/src/test/java/io/github/droidkaigi/confsched2017/viewmodel/TopicColorTest.kt
@@ -23,6 +23,8 @@ class TopicColorTest {
         }
 
         // valid topic id
+        // TODO There is not the specification document about topic id yet.
+        // So, now just see raw json data. https://droidkaigi.github.io/2017/sessions.json
         run {
             assertThat(TopicColor.from(Topic().apply { id = 1 }))
                     .isEqualTo(TopicColor.PRODUCTIVITY_AND_TOOLING)

--- a/app/src/test/java/io/github/droidkaigi/confsched2017/viewmodel/TopicColorTest.kt
+++ b/app/src/test/java/io/github/droidkaigi/confsched2017/viewmodel/TopicColorTest.kt
@@ -24,19 +24,25 @@ class TopicColorTest {
 
         // valid topic id
         run {
-            assertThat(TopicColor.from(Topic().apply { id = TopicColor.PRODUCTIVITY_AND_TOOLING.ordinal }))
+            assertThat(TopicColor.from(Topic().apply { id = 1 }))
                     .isEqualTo(TopicColor.PRODUCTIVITY_AND_TOOLING)
-            assertThat(TopicColor.from(Topic().apply { id = TopicColor.ARCHITECTURE_AND_DEVELOPMENT_PROCESS_METHODOLOGY.ordinal }))
+
+            assertThat(TopicColor.from(Topic().apply { id = 2 }))
                     .isEqualTo(TopicColor.ARCHITECTURE_AND_DEVELOPMENT_PROCESS_METHODOLOGY)
-            assertThat(TopicColor.from(Topic().apply { id = TopicColor.HARDWARE.ordinal }))
+
+            assertThat(TopicColor.from(Topic().apply { id = 3 }))
                     .isEqualTo(TopicColor.HARDWARE)
-            assertThat(TopicColor.from(Topic().apply { id = TopicColor.UI_AND_DESIGN.ordinal }))
+
+            assertThat(TopicColor.from(Topic().apply { id = 4 }))
                     .isEqualTo(TopicColor.UI_AND_DESIGN)
-            assertThat(TopicColor.from(Topic().apply { id = TopicColor.QUALITY_AND_SUSTAINABILITY.ordinal }))
+
+            assertThat(TopicColor.from(Topic().apply { id = 5 }))
                     .isEqualTo(TopicColor.QUALITY_AND_SUSTAINABILITY)
-            assertThat(TopicColor.from(Topic().apply { id = TopicColor.PLATFORM.ordinal }))
+
+            assertThat(TopicColor.from(Topic().apply { id = 6 }))
                     .isEqualTo(TopicColor.PLATFORM)
-            assertThat(TopicColor.from(Topic().apply { id = TopicColor.OTHER.ordinal }))
+
+            assertThat(TopicColor.from(Topic().apply { id = 7 }))
                     .isEqualTo(TopicColor.OTHER)
         }
 

--- a/app/src/test/java/io/github/droidkaigi/confsched2017/viewmodel/TopicColorTest.kt
+++ b/app/src/test/java/io/github/droidkaigi/confsched2017/viewmodel/TopicColorTest.kt
@@ -24,19 +24,19 @@ class TopicColorTest {
 
         // valid topic id
         run {
-            assertThat(TopicColor.from(Topic().apply { id = TopicColor.PRODUCTIVITY_AND_TOOLING.topicId }))
+            assertThat(TopicColor.from(Topic().apply { id = TopicColor.PRODUCTIVITY_AND_TOOLING.ordinal }))
                     .isEqualTo(TopicColor.PRODUCTIVITY_AND_TOOLING)
-            assertThat(TopicColor.from(Topic().apply { id = TopicColor.ARCHITECTURE_AND_DEVELOPMENT_PROCESS_METHODOLOGY.topicId }))
+            assertThat(TopicColor.from(Topic().apply { id = TopicColor.ARCHITECTURE_AND_DEVELOPMENT_PROCESS_METHODOLOGY.ordinal }))
                     .isEqualTo(TopicColor.ARCHITECTURE_AND_DEVELOPMENT_PROCESS_METHODOLOGY)
-            assertThat(TopicColor.from(Topic().apply { id = TopicColor.HARDWARE.topicId }))
+            assertThat(TopicColor.from(Topic().apply { id = TopicColor.HARDWARE.ordinal }))
                     .isEqualTo(TopicColor.HARDWARE)
-            assertThat(TopicColor.from(Topic().apply { id = TopicColor.UI_AND_DESIGN.topicId }))
+            assertThat(TopicColor.from(Topic().apply { id = TopicColor.UI_AND_DESIGN.ordinal }))
                     .isEqualTo(TopicColor.UI_AND_DESIGN)
-            assertThat(TopicColor.from(Topic().apply { id = TopicColor.QUALITY_AND_SUSTAINABILITY.topicId }))
+            assertThat(TopicColor.from(Topic().apply { id = TopicColor.QUALITY_AND_SUSTAINABILITY.ordinal }))
                     .isEqualTo(TopicColor.QUALITY_AND_SUSTAINABILITY)
-            assertThat(TopicColor.from(Topic().apply { id = TopicColor.PLATFORM.topicId }))
+            assertThat(TopicColor.from(Topic().apply { id = TopicColor.PLATFORM.ordinal }))
                     .isEqualTo(TopicColor.PLATFORM)
-            assertThat(TopicColor.from(Topic().apply { id = TopicColor.OTHER.topicId }))
+            assertThat(TopicColor.from(Topic().apply { id = TopicColor.OTHER.ordinal }))
                     .isEqualTo(TopicColor.OTHER)
         }
 

--- a/app/src/test/java/io/github/droidkaigi/confsched2017/viewmodel/TopicColorTest.kt
+++ b/app/src/test/java/io/github/droidkaigi/confsched2017/viewmodel/TopicColorTest.kt
@@ -1,0 +1,44 @@
+package io.github.droidkaigi.confsched2017.viewmodel
+
+import io.github.droidkaigi.confsched2017.model.Topic
+import org.junit.Test
+
+import org.junit.Assert.*
+import org.assertj.core.api.Assertions.assertThat;
+
+class TopicColorTest {
+
+    @Test
+    fun from() {
+
+        // topic is null
+        run {
+            assertThat(TopicColor.from(null)).isEqualTo(TopicColor.NONE)
+        }
+
+        // invalid topic id
+        run {
+            assertThat(TopicColor.from(Topic().apply { id = -1 })).isEqualTo(TopicColor.NONE)
+            assertThat(TopicColor.from(Topic().apply { id = 10 })).isEqualTo(TopicColor.NONE)
+        }
+
+        // valid topic id
+        run {
+            assertThat(TopicColor.from(Topic().apply { id = TopicColor.PRODUCTIVITY_AND_TOOLING.topicId }))
+                    .isEqualTo(TopicColor.PRODUCTIVITY_AND_TOOLING)
+            assertThat(TopicColor.from(Topic().apply { id = TopicColor.ARCHITECTURE_AND_DEVELOPMENT_PROCESS_METHODOLOGY.topicId }))
+                    .isEqualTo(TopicColor.ARCHITECTURE_AND_DEVELOPMENT_PROCESS_METHODOLOGY)
+            assertThat(TopicColor.from(Topic().apply { id = TopicColor.HARDWARE.topicId }))
+                    .isEqualTo(TopicColor.HARDWARE)
+            assertThat(TopicColor.from(Topic().apply { id = TopicColor.UI_AND_DESIGN.topicId }))
+                    .isEqualTo(TopicColor.UI_AND_DESIGN)
+            assertThat(TopicColor.from(Topic().apply { id = TopicColor.QUALITY_AND_SUSTAINABILITY.topicId }))
+                    .isEqualTo(TopicColor.QUALITY_AND_SUSTAINABILITY)
+            assertThat(TopicColor.from(Topic().apply { id = TopicColor.PLATFORM.topicId }))
+                    .isEqualTo(TopicColor.PLATFORM)
+            assertThat(TopicColor.from(Topic().apply { id = TopicColor.OTHER.topicId }))
+                    .isEqualTo(TopicColor.OTHER)
+        }
+
+    }
+}


### PR DESCRIPTION
## Issue

None

## Overview (Required)

I used the order of enum as topic id.

- At first, dd tests.
  - Add test for TopicColor. 1481b0f
  - Remove unused constant values. d114220
- then, change style.
  - Use order as topic id. fffb872
  - Remove topic id field. 1d61fe9

## Links

None

## Screenshot

None
