### PR TITLE
Avoid NullPointerException on showing toast

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SessionFeedbackFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SessionFeedbackFragment.java
@@ -90,6 +90,12 @@ public class SessionFeedbackFragment extends BaseFragment implements SessionFeed
     }
 
     @Override
+    public void onDetach() {
+        super.onDetach();
+        compositeDisposable.clear();
+    }
+
+    @Override
     public void onClickSubmitFeedback() {
         SessionFeedback sessionFeedback = new SessionFeedback(sessionId);
         viewModel.submitSessionFeedback(sessionFeedback)

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SessionFeedbackFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SessionFeedbackFragment.java
@@ -100,11 +100,15 @@ public class SessionFeedbackFragment extends BaseFragment implements SessionFeed
 
     public void onSubmitSuccess() {
         // TODO: show success action
+        if (isDetached())
+            return;
         Toast.makeText(getContext(), "submit success", Toast.LENGTH_SHORT).show();
     }
 
     public void onSubmitFailure() {
         // TODO: show failure action
+        if (isDetached())
+            return;
         Toast.makeText(getContext(), "submit failure", Toast.LENGTH_SHORT).show();
     }
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SessionFeedbackFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SessionFeedbackFragment.java
@@ -98,23 +98,19 @@ public class SessionFeedbackFragment extends BaseFragment implements SessionFeed
     @Override
     public void onClickSubmitFeedback() {
         SessionFeedback sessionFeedback = new SessionFeedback(sessionId);
-        viewModel.submitSessionFeedback(sessionFeedback)
+        compositeDisposable.add(viewModel.submitSessionFeedback(sessionFeedback)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(success -> onSubmitSuccess(), failure -> onSubmitFailure());
+                .subscribe(success -> onSubmitSuccess(), failure -> onSubmitFailure()));
     }
 
     public void onSubmitSuccess() {
         // TODO: show success action
-        if (isDetached())
-            return;
         Toast.makeText(getContext(), "submit success", Toast.LENGTH_SHORT).show();
     }
 
     public void onSubmitFailure() {
         // TODO: show failure action
-        if (isDetached())
-            return;
         Toast.makeText(getContext(), "submit failure", Toast.LENGTH_SHORT).show();
     }
 }


### PR DESCRIPTION
- Avoid calling getContext() after fragment detached