### PR TITLE
Fix calculation of version code

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,7 +40,7 @@ android {
         applicationId packageName
         minSdkVersion min_sdk_version as int
         targetSdkVersion target_sdk_version as int
-        versionCode versionMajor * 100 + versionMinor * 10 + versionPatch
+        versionCode versionMajor * 10000 + versionMinor * 100 + versionPatch
         versionName "${versionMajor}.${versionMinor}.${versionPatch}"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
## Issue
- [#337 at droidkaigi2016](https://github.com/konifar/droidkaigi2016/issues/337)

## Overview (Required)
In current calculation, the version code for the version name may be wrong.
Although it is not a fundamental solution, I think that it can be solved enough with this change. 🤔 

Before:
- 1.11.0 -> 210
- 2.1.0 -> 210

After:
- 1.11.0 -> 10110
- 2.1.0 -> 201000

## Links
none

## Screenshot
none