### PR TITLE
Close search result list when cover taped on search screen.

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SearchFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SearchFragment.java
@@ -174,8 +174,8 @@ public class SearchFragment extends BaseFragment implements SearchViewModel.Call
     }
 
     @Override
-    public void close() {
-        getActivity().finish();
+    public void closeSearchResultList() {
+        adapter.clearAllResults();
     }
 
     @Override
@@ -216,6 +216,11 @@ public class SearchFragment extends BaseFragment implements SearchViewModel.Call
 
         String getPreviousSearchText() {
             return previousSearchText;
+        }
+
+        void clearAllResults() {
+            clear();
+            notifyDataSetChanged();
         }
 
         @Override

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/SearchViewModel.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/SearchViewModel.java
@@ -38,7 +38,7 @@ public final class SearchViewModel extends BaseObservable implements ViewModel {
 
     public void onClickCover(@SuppressWarnings("unused") View view) {
         if (callback != null) {
-            callback.close();
+            callback.closeSearchResultList();
         }
     }
 
@@ -88,7 +88,7 @@ public final class SearchViewModel extends BaseObservable implements ViewModel {
 
     public interface Callback {
 
-        void close();
+        void closeSearchResultList();
     }
 
 }


### PR DESCRIPTION
## Issue
- #224 

## Overview (Required)
Close search result list when cover taped on search screen.
- add `SearchResultsAdapter#clearAllResults` and use it when cover taped.
- rename `Callback#close` to `Callback#closeSearchResultList`.

## Links
N/A

## Screenshot
<img src="https://cloud.githubusercontent.com/assets/5351226/22840128/add66ae2-f00f-11e6-87c1-925033e6083a.gif" width="300" />