### PR TITLE
change argument type(ActivityComponent#inject)

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/di/ActivityComponent.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/di/ActivityComponent.java
@@ -10,7 +10,7 @@ import io.github.droidkaigi.confsched2017.view.activity.*;
 @Subcomponent(modules = ActivityModule.class)
 public interface ActivityComponent{
 
-    <T extends BaseActivity> void inject(T activity);
+    void inject(BaseActivity activity);
 
     FragmentComponent plus(FragmentModule module);
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/di/ActivityComponent.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/di/ActivityComponent.java
@@ -1,30 +1,16 @@
 package io.github.droidkaigi.confsched2017.di;
 
 
+import android.app.Activity;
 import dagger.Subcomponent;
 import io.github.droidkaigi.confsched2017.di.scope.ActivityScope;
-import io.github.droidkaigi.confsched2017.view.activity.ContributorsActivity;
-import io.github.droidkaigi.confsched2017.view.activity.LicensesActivity;
-import io.github.droidkaigi.confsched2017.view.activity.MainActivity;
-import io.github.droidkaigi.confsched2017.view.activity.SessionDetailActivity;
-import io.github.droidkaigi.confsched2017.view.activity.SessionFeedbackActivity;
-import io.github.droidkaigi.confsched2017.view.activity.SponsorsActivity;
+import io.github.droidkaigi.confsched2017.view.activity.*;
 
 @ActivityScope
 @Subcomponent(modules = ActivityModule.class)
-public interface ActivityComponent {
+public interface ActivityComponent{
 
-    void inject(MainActivity activity);
-
-    void inject(SessionDetailActivity activity);
-
-    void inject(SponsorsActivity activity);
-
-    void inject(ContributorsActivity activity);
-
-    void inject(LicensesActivity activity);
-
-    void inject(SessionFeedbackActivity activity);
+    <T extends BaseActivity> void inject(T activity);
 
     FragmentComponent plus(FragmentModule module);
 }


### PR DESCRIPTION
## Issue

I think ActivityComponent inject method is too many.
My proposal is change argument type. 
<del>My proposal is use type parameter. Generic type parameter solves this issue.</del>

## Overview (Required)

ActivityComponent inteface seems simply inject Activity instance.
But it's provides overload  methods each subclass :

```java
void inject(XXXActivity activity);
```

This approach cause increase method when Activity added.


I thought BaseActivity is boundary type for inject method in droidkaigi app.
So inject method definition is :

<del>
```java
T extends BaseActivity
```
</del>

```
void inject(BaseActivity activity);
```

Honestly, I want to use generic type parameter,but Dagger2 seems not allow it.



## Links

* Effective Java(Item 28: Use bounded wildcards to increase API flexibility. )
* [Dagger 2 Generic Type class inject error](http://stackoverflow.com/questions/32498912/dagger-2-generic-type-class-inject-error)


## Screenshot

None.
