### PR TITLE
fix wrong label

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -52,7 +52,7 @@
                 android:name=".view.activity.ContributorsActivity"
                 android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation"
                 android:exported="false"
-                android:label="@string/sponsors"
+                android:label="@string/contributors"
                 android:theme="@style/AppTheme.ColoredStatusBar"
                 />
 


### PR DESCRIPTION
## Issue
- None

## Overview (Required)
- Before: `ContributorsActivity` has "Sponsors" as label.  
Seems that is wrong.  
I think, "Contributors" is ok.

## Links
- None

## Screenshot
None


By the way, we really need `android:label` property for not `LAUNCHER` Activity...?
https://developer.android.com/guide/topics/manifest/activity-element.html?hl=ja#label