### PR TITLE
remove lint error

### DIFF
--- a/app/src/main/res/values/fonts.xml
+++ b/app/src/main/res/values/fonts.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <string name="font_noto_cjk_light">fonts/GenShinGothic-P-Light.ttf</string>
-    <string name="font_noto_cjk_medium">fonts/GenShinGothic-P-Medium.ttf</string>
-    <string name="font_noto_cjk_regular">fonts/GenShinGothic-P-Regular.ttf</string>
+    <string name="font_noto_cjk_light" translatable="false">fonts/GenShinGothic-P-Light.ttf</string>
+    <string name="font_noto_cjk_medium" translatable="false">fonts/GenShinGothic-P-Medium.ttf</string>
+    <string name="font_noto_cjk_regular" translatable="false">fonts/GenShinGothic-P-Regular.ttf</string>
 
 </resources>


### PR DESCRIPTION
## Issue
- None

## Overview (Required)
- Reduce lint error about "MissingTranslation".

I think, not needed translate about font file name.
So I add `translatable="false"`.

I really want, reduce all of error about "MissingTranslation". But I don't know about onesky...

## Links
- None

## Screenshot
Before | After
:--: | :--:
<img src="https://cloud.githubusercontent.com/assets/1567757/22851639/e730ca38-f06b-11e6-8857-ede80d10233f.png" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/1567757/22851631/b3114a0c-f06b-11e6-90dc-32c47ca3a27b.png" width="300" />
