### PR TITLE
Fix WrongConstant error on lint.

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/util/AppShortcutsUtil.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/util/AppShortcutsUtil.java
@@ -1,5 +1,6 @@
 package io.github.droidkaigi.confsched2017.util;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ShortcutInfo;
@@ -21,6 +22,8 @@ public class AppShortcutsUtil {
 
     @RequiresApi(api = Build.VERSION_CODES.N_MR1)
     public static void addShortcuts(@NonNull Context context) {
+
+        @SuppressLint({"WrongConstant"})
         ShortcutManager shortcutManager = (ShortcutManager) context.getSystemService(Context.SHORTCUT_SERVICE);
 
         if (shortcutManager != null) {


### PR DESCRIPTION
Hi! It's a great app!

## Issue
- None 

## Overview (Required)
- A WrongConstant error occurred in `AppShortcutsUtil` when executing lint.
- The cause of this problem is the Gradle Plugins error.
  - https://code.google.com/p/android/issues/detail?id=226891
- Therefore, I added `@SuppressLint ({"WrongConstant"})`.

## Links
- None 

## Screenshot
Before | After
:--: | :--:
<img src="https://cloud.githubusercontent.com/assets/1620566/22851721/748b091e-f06e-11e6-812f-cf361f620d9d.png" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/1620566/22851750/ea81e23c-f06e-11e6-8f1f-725dc86df29b.png" width="300" />
