### PR TITLE
Enable lint text report

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -110,6 +110,8 @@ android {
     lintOptions {
         disable 'InvalidPackage'
         abortOnError false
+        textReport true
+        textOutput 'stdout'
         lintConfig file("lint.xml")
     }
 


### PR DESCRIPTION
## Issue
#266 

## Overview (Required)
Since some people now working on lint, let's add text report setting so that we can check the error in circle ci.

## Links
https://google.github.io/android-gradle-dsl/current/com.android.build.gradle.internal.dsl.LintOptions.html#com.android.build.gradle.internal.dsl.LintOptions:textOutput

https://google.github.io/android-gradle-dsl/current/com.android.build.gradle.internal.dsl.LintOptions.html#com.android.build.gradle.internal.dsl.LintOptions:textReport

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
