### PR TITLE
split repository link from list item

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/ContributorsActivity.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/ContributorsActivity.java
@@ -3,8 +3,12 @@ package io.github.droidkaigi.confsched2017.view.activity;
 import android.app.Activity;
 import android.content.Intent;
 import android.databinding.DataBindingUtil;
+import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 
 import io.github.droidkaigi.confsched2017.R;
 import io.github.droidkaigi.confsched2017.databinding.ActivityContributorsBinding;
@@ -27,5 +31,24 @@ public class ContributorsActivity extends BaseActivity {
 
         initBackToolbar(binding.toolbar);
         replaceFragment(ContributorsFragment.newInstance(), R.id.content_view);
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        MenuInflater inflater = getMenuInflater();
+        inflater.inflate(R.menu.menu_contributors, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case R.id.item_repository:
+                Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/DroidKaigi/conference-app-2017"));
+                startActivity(intent);
+                return true;
+            default:
+                return super.onOptionsItemSelected(item);
+        }
     }
 }

--- a/app/src/main/res/menu/menu_contributors.xml
+++ b/app/src/main/res/menu/menu_contributors.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        >
+
+    <item
+            android:id="@+id/item_repository"
+            android:icon="@drawable/ic_information_24_vector"
+            android:orderInCategory="100"
+            android:title="@string/contributors_open_repository"
+            app:showAsAction="always"
+            />
+
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,7 +59,7 @@
     <string name="info_sponsors_description">DroidKaigi is supported by many sponsors. Thank you so much!</string>
     <string name="info_questionnaire_title">Questionnaire</string>
     <string name="info_questionnaire_description">Please cooperate with the questionnaire to improve DroidKaigi.</string>
-    <string name="info_contributors_description">Awesome contributors for this app. you can contribute from https://github.com/DroidKaigi/conference-app-2017</string>
+    <string name="info_contributors_description">Awesome contributors for this app.</string>
     <string name="info_help_translate">Your contribution is much appreciated! Tap here to contribute.</string>
     <string name="info_license_title">Licenses</string>
     <string name="info_license_description">This app uses many awesome libraries. Thank you so much!</string>
@@ -73,6 +73,7 @@
     <!-- Contributors -->
     <string name="contributors">Contributors</string>
     <string name="contributors_people">(%1$d people)</string>
+    <string name="contributors_open_repository">Repository</string>
 
     <string name="help_translate">Help Translate</string>
 


### PR DESCRIPTION
## Issue
- https://github.com/DroidKaigi/conference-app-2017/issues/169

## Overview (Required)
- Extract link url from list item.
- Add menu item for opening repository url.

This is same as you want..?
> remove the link from the description and add the link menu icon to the contributor page?

## Links
- None

## Screenshot
Before | After
:--: | :--:
<img src="https://cloud.githubusercontent.com/assets/1567757/22852137/47f5bbf0-f079-11e6-828a-0e34bcbabd21.png" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/1567757/22852119/05c6d5de-f079-11e6-923c-4fd954e21290.png" width="300" />
<img src="https://cloud.githubusercontent.com/assets/1567757/22852141/529ea8c8-f079-11e6-9f6a-db18da6c3328.png" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/1567757/22852123/0f101a2e-f079-11e6-8acf-ee675d6c5b5a.png" width="300" />
