### PR TITLE
Remove unused SessionFeedbackViewModel injection.

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/SessionFeedbackActivity.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/SessionFeedbackActivity.java
@@ -6,21 +6,15 @@ import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 
-import javax.inject.Inject;
-
 import io.github.droidkaigi.confsched2017.R;
 import io.github.droidkaigi.confsched2017.databinding.ActivitySessionFeedbackBinding;
 import io.github.droidkaigi.confsched2017.view.fragment.SessionFeedbackFragmentCreator;
-import io.github.droidkaigi.confsched2017.viewmodel.SessionFeedbackViewModel;
 
 public class SessionFeedbackActivity extends BaseActivity {
 
     private static final String TAG = SessionFeedbackActivity.class.getSimpleName();
 
     private static final String EXTRA_SESSION_ID = "session_id";
-
-    @Inject
-    SessionFeedbackViewModel viewModel;
 
     private ActivitySessionFeedbackBinding binding;
 


### PR DESCRIPTION
## Issue
None

## Overview (Required)
- `SessionFeedbackViewModel` is not used in `SessionFeedbackActivity` so I have removed it's injection.
