### PR TITLE
Fixed the output of the log message by Timber's recommended way.

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/util/LocaleUtil.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/util/LocaleUtil.java
@@ -85,11 +85,11 @@ public class LocaleUtil {
             if (resourceId > 0) {
                 return context.getString(resourceId);
             } else {
-                Timber.tag(TAG).d("String resource id: " + resName + " is not found.");
+                Timber.tag(TAG).d("String resource id: %s is not found.", resName);
                 return "";
             }
         } catch (Exception e) {
-            Timber.tag(TAG).e("String resource id: " + resName + " is not found.", e);
+            Timber.tag(TAG).e(e, "String resource id: %s is not found.", resName);
             return "";
         }
     }
@@ -113,7 +113,7 @@ public class LocaleUtil {
         try {
             return formatLocal.parse(formatTokyo.format(date));
         } catch (ParseException e) {
-            Timber.tag(TAG).e(e, "date: " + date + "can not parse.");
+            Timber.tag(TAG).e(e, "date: %s can not parse.", date.toString());
             return date;
         }
     }

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SettingsFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SettingsFragment.java
@@ -73,11 +73,11 @@ public class SettingsFragment extends BaseFragment implements SettingsViewModel.
                 .collect(Collectors.toList());
 
         String currentLanguageId = LocaleUtil.getCurrentLanguageId(getActivity());
-        Timber.tag(TAG).d("current language_id: " + currentLanguageId);
-        Timber.tag(TAG).d("languageIds: " + languageIds.toString());
+        Timber.tag(TAG).d("current language_id: %s", currentLanguageId);
+        Timber.tag(TAG).d("languageIds: %s", languageIds.toString());
 
         int defaultItem = languageIds.indexOf(currentLanguageId);
-        Timber.tag(TAG).d("current language_id index: " + defaultItem);
+        Timber.tag(TAG).d("current language_id index: %s", defaultItem);
 
         String[] items = languages.toArray(new String[languages.size()]);
         new AlertDialog.Builder(getActivity())
@@ -85,7 +85,7 @@ public class SettingsFragment extends BaseFragment implements SettingsViewModel.
                 .setSingleChoiceItems(items, defaultItem, (dialog, which) -> {
                     String selectedLanguageId = languageIds.get(which);
                     if (!currentLanguageId.equals(selectedLanguageId)) {
-                        Timber.tag(TAG).d("Selected language_id: " + selectedLanguageId);
+                        Timber.tag(TAG).d("Selected language_id: %s", selectedLanguageId);
                         LocaleUtil.setLocale(getActivity(), selectedLanguageId);
                         dialog.dismiss();
                         restart();


### PR DESCRIPTION
## Issue
- None

## Overview (Required)
- `BinaryOperationInTimber` occurred when executing lint.
  - This is caused by a [lint rule embedded in Timber](https://github.com/JakeWharton/timber#lint).
- Timber internally uses `String.format` to format log messages.
- Therefore, I changed the format of the log message to the way Timber recommends.

## Links
- None

## Screenshot
Before | After
:--: | :--:
<img src="https://cloud.githubusercontent.com/assets/1620566/22854203/90f28ea4-f0ac-11e6-86ea-16c387e45b54.png" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/1620566/22854215/e2caa1da-f0ac-11e6-821f-7cb6d81580b5.png" width="300" />