### PR TITLE
Ignore MissingPrefix error that occurs when lint is executed.

### DIFF
--- a/app/src/main/res/drawable-v21/avd_add_to_check_24dp.xml
+++ b/app/src/main/res/drawable-v21/avd_add_to_check_24dp.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <animated-vector xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:aapt="http://schemas.android.com/aapt"
+        xmlns:tools="http://schemas.android.com/tools"
         >
-    <aapt:attr name="android:drawable">
+    <aapt:attr name="android:drawable"
+            tools:ignore="MissingPrefix">
         <vector xmlns:android="http://schemas.android.com/apk/res/android"
                 android:width="24dp"
                 android:height="24dp"
@@ -24,7 +26,8 @@
         </vector>
     </aapt:attr>
     <target android:name="group">
-        <aapt:attr name="android:animation">
+        <aapt:attr name="android:animation"
+                tools:ignore="MissingPrefix">
             <set xmlns:android="http://schemas.android.com/apk/res/android">
                 <objectAnimator
                         android:duration="@integer/fab_vector_animation_mills"
@@ -38,7 +41,8 @@
         </aapt:attr>
     </target>
     <target android:name="ic_add">
-        <aapt:attr name="android:animation">
+        <aapt:attr name="android:animation"
+                tools:ignore="MissingPrefix">
             <objectAnimator xmlns:android="http://schemas.android.com/apk/res/android"
                     android:name="ic_add"
                     android:duration="@integer/fab_vector_animation_mills"

--- a/app/src/main/res/drawable-v21/avd_check_to_add_24dp.xml
+++ b/app/src/main/res/drawable-v21/avd_check_to_add_24dp.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <animated-vector xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:aapt="http://schemas.android.com/aapt"
+        xmlns:tools="http://schemas.android.com/tools"
         >
-    <aapt:attr name="android:drawable">
+    <aapt:attr name="android:drawable"
+            tools:ignore="MissingPrefix">
         <vector xmlns:android="http://schemas.android.com/apk/res/android"
                 android:width="24dp"
                 android:height="24dp"
@@ -24,7 +26,8 @@
         </vector>
     </aapt:attr>
     <target android:name="group">
-        <aapt:attr name="android:animation">
+        <aapt:attr name="android:animation"
+                tools:ignore="MissingPrefix">
             <set xmlns:android="http://schemas.android.com/apk/res/android">
                 <objectAnimator
                         android:name="group"
@@ -39,7 +42,8 @@
         </aapt:attr>
     </target>
     <target android:name="ic_check">
-        <aapt:attr name="android:animation">
+        <aapt:attr name="android:animation"
+                tools:ignore="MissingPrefix">
             <objectAnimator xmlns:android="http://schemas.android.com/apk/res/android"
                     android:name="ic_check"
                     android:duration="@integer/fab_vector_animation_mills"

--- a/app/src/main/res/drawable/avd_add_to_check_24dp.xml
+++ b/app/src/main/res/drawable/avd_add_to_check_24dp.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <animated-vector xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:aapt="http://schemas.android.com/aapt"
+        xmlns:tools="http://schemas.android.com/tools"
         >
-    <aapt:attr name="android:drawable">
+    <aapt:attr name="android:drawable"
+            tools:ignore="MissingPrefix">
         <vector xmlns:android="http://schemas.android.com/apk/res/android"
                 android:width="24dp"
                 android:height="24dp"
@@ -24,7 +26,8 @@
         </vector>
     </aapt:attr>
     <target android:name="group">
-        <aapt:attr name="android:animation">
+        <aapt:attr name="android:animation"
+                tools:ignore="MissingPrefix">
             <set xmlns:android="http://schemas.android.com/apk/res/android">
                 <objectAnimator
                         android:duration="@integer/fab_vector_animation_mills"

--- a/app/src/main/res/drawable/avd_check_to_add_24dp.xml
+++ b/app/src/main/res/drawable/avd_check_to_add_24dp.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <animated-vector xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:aapt="http://schemas.android.com/aapt"
+        xmlns:tools="http://schemas.android.com/tools"
         >
-    <aapt:attr name="android:drawable">
+    <aapt:attr name="android:drawable"
+            tools:ignore="MissingPrefix">
         <vector xmlns:android="http://schemas.android.com/apk/res/android"
                 android:width="24dp"
                 android:height="24dp"
@@ -24,7 +26,8 @@
         </vector>
     </aapt:attr>
     <target android:name="group">
-        <aapt:attr name="android:animation">
+        <aapt:attr name="android:animation"
+                tools:ignore="MissingPrefix">
             <set xmlns:android="http://schemas.android.com/apk/res/android">
                 <objectAnimator
                         android:name="group"


### PR DESCRIPTION
## Issue
- #266

## Overview (Required)
- Ignore `MissingPrefix` lint error.
- This error is false detection of lint.
- Therefore, I added `tools: ignore = "MissingPrefix"`.

## Links
- None

## Screenshot
Before | After
:--: | :--:
<img src="https://cloud.githubusercontent.com/assets/1620566/22855023/48caacd2-f0bc-11e6-8b54-e45e34c3efd1.png" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/1620566/22855043/8bb7c188-f0bc-11e6-8024-ca559aed2b0b.png" width="300" />