### PR TITLE
More MVVM for Contributors view

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/di/ActivityComponent.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/di/ActivityComponent.java
@@ -12,5 +12,7 @@ public interface ActivityComponent{
 
     void inject(BaseActivity activity);
 
+    void inject(ContributorsActivity activity);
+
     FragmentComponent plus(FragmentModule module);
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/di/AppModule.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/di/AppModule.java
@@ -8,6 +8,7 @@ import com.jakewharton.retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
 import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.support.annotation.StringRes;
 
 import javax.inject.Singleton;
 
@@ -19,6 +20,7 @@ import io.github.droidkaigi.confsched2017.api.service.GithubService;
 import io.github.droidkaigi.confsched2017.api.service.GoogleFormService;
 import io.github.droidkaigi.confsched2017.model.OrmaDatabase;
 import io.github.droidkaigi.confsched2017.pref.DefaultPrefs;
+import io.github.droidkaigi.confsched2017.view.helper.ResourceResolver;
 import io.reactivex.disposables.CompositeDisposable;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
@@ -102,6 +104,21 @@ public class AppModule {
                 .addConverterFactory(GsonConverterFactory.create(createGson()))
                 .build()
                 .create(GoogleFormService.class);
+    }
+
+    @Provides
+    public ResourceResolver provideResourceResolver(final Context context) {
+        return new ResourceResolver() {
+            @Override
+            public String getString(@StringRes int resId) {
+                return context.getString(resId);
+            }
+
+            @Override
+            public String getString(@StringRes int resId, Object... formatArgs) {
+                return context.getString(resId, formatArgs);
+            }
+        };
     }
 
     private static Gson createGson() {

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/ContributorsActivity.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/ContributorsActivity.java
@@ -10,13 +10,19 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 
+import javax.inject.Inject;
+
 import io.github.droidkaigi.confsched2017.R;
 import io.github.droidkaigi.confsched2017.databinding.ActivityContributorsBinding;
 import io.github.droidkaigi.confsched2017.view.fragment.ContributorsFragment;
+import io.github.droidkaigi.confsched2017.viewmodel.ToolbarViewModel;
 
 public class ContributorsActivity extends BaseActivity {
 
     private ActivityContributorsBinding binding;
+
+    @Inject
+    ToolbarViewModel viewModel;
 
     public static void start(@NonNull Activity activity) {
         Intent intent = new Intent(activity, ContributorsActivity.class);
@@ -26,10 +32,13 @@ public class ContributorsActivity extends BaseActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        binding = DataBindingUtil.setContentView(this, R.layout.activity_contributors);
         getComponent().inject(this);
 
+        binding = DataBindingUtil.setContentView(this, R.layout.activity_contributors);
+        binding.setViewModel(viewModel);
+
         initBackToolbar(binding.toolbar);
+        viewModel.setToolbarTitle(getString(R.string.contributors));
         replaceFragment(ContributorsFragment.newInstance(), R.id.content_view);
     }
 

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/helper/ResourceResolver.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/helper/ResourceResolver.java
@@ -1,0 +1,10 @@
+package io.github.droidkaigi.confsched2017.view.helper;
+
+import android.support.annotation.StringRes;
+
+public interface ResourceResolver {
+
+    String getString(@StringRes int resId);
+
+    String getString(@StringRes int resId, Object... formatArgs);
+}

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/ContributorsViewModel.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/ContributorsViewModel.java
@@ -16,10 +16,12 @@ import java.util.List;
 import javax.inject.Inject;
 
 import io.github.droidkaigi.confsched2017.BR;
+import io.github.droidkaigi.confsched2017.di.scope.FragmentScope;
 import io.github.droidkaigi.confsched2017.repository.contributors.ContributorsRepository;
 import io.reactivex.Single;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 
+@FragmentScope
 public final class ContributorsViewModel extends BaseObservable implements ViewModel, ContributorViewModel.Callback {
 
     private final ContributorsRepository contributorsRepository;

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/ContributorsViewModel.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/ContributorsViewModel.java
@@ -3,7 +3,6 @@ package io.github.droidkaigi.confsched2017.viewmodel;
 import com.annimon.stream.Collectors;
 import com.annimon.stream.Stream;
 
-import android.content.Context;
 import android.databinding.BaseObservable;
 import android.databinding.Bindable;
 import android.databinding.ObservableArrayList;
@@ -20,6 +19,7 @@ import io.github.droidkaigi.confsched2017.BR;
 import io.github.droidkaigi.confsched2017.R;
 import io.github.droidkaigi.confsched2017.di.scope.FragmentScope;
 import io.github.droidkaigi.confsched2017.repository.contributors.ContributorsRepository;
+import io.github.droidkaigi.confsched2017.view.helper.ResourceResolver;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.disposables.Disposable;
@@ -31,7 +31,7 @@ public final class ContributorsViewModel extends BaseObservable implements ViewM
 
     public static final String TAG = ContributorsViewModel.class.getSimpleName();
 
-    private final Context context;
+    private final ResourceResolver resourceResolver;
 
     private final ToolbarViewModel toolbarViewModel;
 
@@ -49,9 +49,9 @@ public final class ContributorsViewModel extends BaseObservable implements ViewM
     private Callback callback;
 
     @Inject
-    ContributorsViewModel(Context context, ToolbarViewModel toolbarViewModel, ContributorsRepository contributorsRepository,
-            CompositeDisposable compositeDisposable) {
-        this.context = context;
+    ContributorsViewModel(ResourceResolver resourceResolver, ToolbarViewModel toolbarViewModel,
+            ContributorsRepository contributorsRepository, CompositeDisposable compositeDisposable) {
+        this.resourceResolver = resourceResolver;
         this.toolbarViewModel = toolbarViewModel;
         this.contributorsRepository = contributorsRepository;
         this.compositeDisposable = compositeDisposable;
@@ -130,8 +130,8 @@ public final class ContributorsViewModel extends BaseObservable implements ViewM
         viewModels.clear();
         viewModels.addAll(contributorViewModels);
 
-        String title = context.getString(R.string.contributors) + " "
-                + context.getString(R.string.contributors_people, contributorViewModels.size());
+        String title = resourceResolver.getString(R.string.contributors) + " "
+                + resourceResolver.getString(R.string.contributors_people, contributorViewModels.size());
         toolbarViewModel.setToolbarTitle(title);
 
         setLoadingVisibility(View.GONE);

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/ToolbarViewModel.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/ToolbarViewModel.java
@@ -1,0 +1,32 @@
+package io.github.droidkaigi.confsched2017.viewmodel;
+
+import com.android.databinding.library.baseAdapters.BR;
+
+import android.databinding.BaseObservable;
+import android.databinding.Bindable;
+
+import javax.inject.Inject;
+
+public final class ToolbarViewModel extends BaseObservable implements ViewModel {
+
+    private String toolbarTitle;
+
+    @Inject
+    public ToolbarViewModel() {
+    }
+
+    @Bindable
+    public String getToolbarTitle() {
+        return toolbarTitle;
+    }
+
+    public void setToolbarTitle(String title) {
+        toolbarTitle = title;
+        notifyPropertyChanged(BR.toolbarTitle);
+    }
+
+    @Override
+    public void destroy() {
+        // Nothing to do
+    }
+}

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/ToolbarViewModel.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/ToolbarViewModel.java
@@ -7,6 +7,9 @@ import android.databinding.Bindable;
 
 import javax.inject.Inject;
 
+import io.github.droidkaigi.confsched2017.di.scope.ActivityScope;
+
+@ActivityScope
 public final class ToolbarViewModel extends BaseObservable implements ViewModel {
 
     private String toolbarTitle;

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/ToolbarViewModel.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/ToolbarViewModel.java
@@ -10,7 +10,7 @@ import javax.inject.Inject;
 import io.github.droidkaigi.confsched2017.di.scope.ActivityScope;
 
 @ActivityScope
-public final class ToolbarViewModel extends BaseObservable implements ViewModel {
+public class ToolbarViewModel extends BaseObservable implements ViewModel {
 
     private String toolbarTitle;
 

--- a/app/src/main/res/layout/activity_contributors.xml
+++ b/app/src/main/res/layout/activity_contributors.xml
@@ -3,6 +3,14 @@
         xmlns:app="http://schemas.android.com/apk/res-auto"
         >
 
+    <data>
+
+        <variable
+                name="viewModel"
+                type="io.github.droidkaigi.confsched2017.viewmodel.ToolbarViewModel"
+                />
+    </data>
+
     <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
@@ -13,7 +21,7 @@
                 style="@style/BaseToolbar"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:title="@string/contributors"
+                app:title="@{viewModel.toolbarTitle}"
                 />
 
         <FrameLayout

--- a/app/src/test/java/io/github/droidkaigi/confsched2017/util/RxTestSchedulerRule.kt
+++ b/app/src/test/java/io/github/droidkaigi/confsched2017/util/RxTestSchedulerRule.kt
@@ -1,0 +1,23 @@
+package io.github.droidkaigi.confsched2017.util
+
+import io.reactivex.android.plugins.RxAndroidPlugins
+import io.reactivex.plugins.RxJavaPlugins
+import io.reactivex.schedulers.TestScheduler
+import org.junit.rules.ExternalResource
+
+class RxTestSchedulerRule : ExternalResource() {
+    val testScheduler: TestScheduler = TestScheduler()
+
+    override fun before() {
+        RxJavaPlugins.reset()
+        RxJavaPlugins.setInitIoSchedulerHandler { testScheduler }
+
+        RxAndroidPlugins.reset()
+        RxAndroidPlugins.setInitMainThreadSchedulerHandler { testScheduler }
+    }
+
+    override fun after() {
+        RxJavaPlugins.reset()
+        RxAndroidPlugins.reset()
+    }
+}

--- a/app/src/test/java/io/github/droidkaigi/confsched2017/viewmodel/ContributorsViewModelTest.kt
+++ b/app/src/test/java/io/github/droidkaigi/confsched2017/viewmodel/ContributorsViewModelTest.kt
@@ -1,0 +1,107 @@
+package io.github.droidkaigi.confsched2017.viewmodel
+
+import com.sys1yagi.kmockito.any
+import com.sys1yagi.kmockito.invoked
+import com.sys1yagi.kmockito.mock
+import com.sys1yagi.kmockito.verify
+import com.taroid.knit.should
+import io.github.droidkaigi.confsched2017.model.Contributor
+import io.github.droidkaigi.confsched2017.repository.contributors.ContributorsRepository
+import io.github.droidkaigi.confsched2017.util.RxTestSchedulerRule
+import io.github.droidkaigi.confsched2017.view.helper.ResourceResolver
+import io.reactivex.Single
+import io.reactivex.disposables.CompositeDisposable
+import org.junit.After
+import org.junit.Before
+import org.junit.ClassRule
+import org.junit.Test
+import org.mockito.Mockito.never
+
+class ContributorsViewModelTest {
+
+    companion object {
+        @ClassRule
+        @JvmField
+        val schedulerRule = RxTestSchedulerRule()
+
+        private val EXPECTED_CONTRIBUTORS = listOf(
+                Contributor().apply {
+                    name = "Alice"
+                    htmlUrl = "AliceUrl"
+                },
+                Contributor().apply {
+                    name = "Bob"
+                },
+                Contributor().apply {
+                    name = "Charlie"
+                }
+        )
+    }
+
+    private val resourceResolver = object : ResourceResolver {
+        override fun getString(resId: Int): String = "Contributors"
+
+        override fun getString(resId: Int, vararg formatArgs: Any?): String = "(${formatArgs[0]} people)"
+    }
+
+    private val toolbarViewModel = mock<ToolbarViewModel>()
+
+    private val repository = mock<ContributorsRepository>().apply {
+        findAll().invoked.thenReturn(Single.just(EXPECTED_CONTRIBUTORS))
+    }
+
+    private lateinit var viewModel: ContributorsViewModel
+
+    @Before
+    fun setUp() {
+        viewModel = ContributorsViewModel(resourceResolver, toolbarViewModel, repository, CompositeDisposable())
+    }
+
+    @After
+    fun tearDown() {
+        viewModel.destroy()
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun start() {
+        viewModel.start()
+        schedulerRule.testScheduler.triggerActions()
+
+        assertEq(viewModel.contributorViewModels, EXPECTED_CONTRIBUTORS)
+        viewModel.loadingVisibility.should be 8 // GONE
+        viewModel.refreshing.should be false
+        toolbarViewModel.verify().setToolbarTitle("Contributors (3 people)")
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun onSwipeRefresh() {
+        viewModel.onSwipeRefresh()
+        schedulerRule.testScheduler.triggerActions()
+
+        assertEq(viewModel.contributorViewModels, EXPECTED_CONTRIBUTORS)
+        viewModel.loadingVisibility.should be 8 // GONE
+        viewModel.refreshing.should be false
+        toolbarViewModel.verify().setToolbarTitle("Contributors (3 people)")
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun onContributorClick() {
+        val callback = mock<ContributorsViewModel.Callback>()
+        viewModel.setCallback(callback)
+
+        viewModel.start()
+        schedulerRule.testScheduler.triggerActions()
+
+        callback.verify(never()).onClickContributor(any())
+        viewModel.contributorViewModels[0].onClickContributor(null)
+        callback.verify().onClickContributor("AliceUrl")
+    }
+
+    private fun assertEq(actual: List<ContributorViewModel>, expected: List<Contributor>) {
+        actual.size.should be expected.size
+        actual.map { it.name }.should be expected.map { it.name }
+    }
+}


### PR DESCRIPTION
## Issue
None

## Overview (Required)
The purpose of this PR is `ContributorsFragment` makes thin and `ContributorsViewModel` makes testable.

- Apply MVVM pattern to Toolbar title.
- Move logic (rendering contributors) from `ContributorsFragment` to `ContributorsViewModel`.
- Add tests for `ContributorsViewModel`.
