### PR TITLE
Unify method of calling Activity to `createIntent`

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/ContributorsActivity.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/ContributorsActivity.java
@@ -1,11 +1,10 @@
 package io.github.droidkaigi.confsched2017.view.activity;
 
-import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.databinding.DataBindingUtil;
 import android.net.Uri;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -18,9 +17,8 @@ public class ContributorsActivity extends BaseActivity {
 
     private ActivityContributorsBinding binding;
 
-    public static void start(@NonNull Activity activity) {
-        Intent intent = new Intent(activity, ContributorsActivity.class);
-        activity.startActivity(intent);
+    public static Intent createIntent(Context context) {
+        return new Intent(context, ContributorsActivity.class);
     }
 
     @Override

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/LicensesActivity.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/LicensesActivity.java
@@ -1,10 +1,9 @@
 package io.github.droidkaigi.confsched2017.view.activity;
 
-import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 
 import io.github.droidkaigi.confsched2017.R;
 import io.github.droidkaigi.confsched2017.databinding.ActivityLicensesBinding;
@@ -14,9 +13,8 @@ public class LicensesActivity extends BaseActivity {
 
     private ActivityLicensesBinding binding;
 
-    public static void start(@NonNull Activity activity) {
-        Intent intent = new Intent(activity, LicensesActivity.class);
-        activity.startActivity(intent);
+    public static Intent createIntent(Context context) {
+        return new Intent(context, LicensesActivity.class);
     }
 
     @Override

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/MainActivity.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/MainActivity.java
@@ -1,6 +1,6 @@
 package io.github.droidkaigi.confsched2017.view.activity;
 
-import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
@@ -30,9 +30,8 @@ public class MainActivity extends BaseActivity {
 
     private Fragment settingsFragment;
 
-    public static void start(@NonNull Activity activity) {
-        Intent intent = new Intent(activity, MainActivity.class);
-        activity.startActivity(intent);
+    public static Intent createIntent(Context context) {
+        return new Intent(context, MainActivity.class);
     }
 
     @Override

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/SearchActivity.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/SearchActivity.java
@@ -1,10 +1,9 @@
 package io.github.droidkaigi.confsched2017.view.activity;
 
-import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 
 import io.github.droidkaigi.confsched2017.R;
 import io.github.droidkaigi.confsched2017.databinding.ActivitySearchBinding;
@@ -14,15 +13,14 @@ public class SearchActivity extends BaseActivity {
 
     private ActivitySearchBinding binding;
 
-    public static void start(@NonNull Activity activity) {
-        Intent intent = new Intent(activity, SearchActivity.class);
-        activity.startActivity(intent);
-        activity.overridePendingTransition(0, R.anim.activity_fade_exit);
+    public static Intent createIntent(Context context) {
+        return new Intent(context, SearchActivity.class);
     }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        overridePendingTransition(0, R.anim.activity_fade_exit);
         binding = DataBindingUtil.setContentView(this, R.layout.activity_search);
 
         initBackToolbar(binding.toolbar);

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/SponsorsActivity.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/SponsorsActivity.java
@@ -1,10 +1,9 @@
 package io.github.droidkaigi.confsched2017.view.activity;
 
-import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 
 import io.github.droidkaigi.confsched2017.R;
 import io.github.droidkaigi.confsched2017.databinding.ActivitySponsorsBinding;
@@ -14,9 +13,8 @@ public class SponsorsActivity extends BaseActivity {
 
     private ActivitySponsorsBinding binding;
 
-    public static void start(@NonNull Activity activity) {
-        Intent intent = new Intent(activity, SponsorsActivity.class);
-        activity.startActivity(intent);
+    public static Intent createIntent(Context context) {
+        return new Intent(context, SponsorsActivity.class);
     }
 
     @Override

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/InformationFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/InformationFragment.java
@@ -60,7 +60,7 @@ public class InformationFragment extends BaseFragment implements InformationView
 
     @Override
     public void showSponsorsPage() {
-        SponsorsActivity.start(getActivity());
+        startActivity(SponsorsActivity.createIntent(getActivity()));
     }
 
     @Override
@@ -70,7 +70,7 @@ public class InformationFragment extends BaseFragment implements InformationView
 
     @Override
     public void showContributorsPage() {
-        ContributorsActivity.start(getActivity());
+        startActivity(ContributorsActivity.createIntent(getActivity()));
     }
 
     @Override
@@ -80,7 +80,7 @@ public class InformationFragment extends BaseFragment implements InformationView
 
     @Override
     public void showLicensePage() {
-        LicensesActivity.start(getActivity());
+        startActivity(LicensesActivity.createIntent(getActivity()));
     }
 
     @Override

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SessionsFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SessionsFragment.java
@@ -99,7 +99,7 @@ public class SessionsFragment extends BaseFragment implements SessionViewModel.C
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case R.id.item_search:
-                SearchActivity.start(getActivity());
+                startActivity(SearchActivity.createIntent(getActivity()));
                 break;
         }
         return super.onOptionsItemSelected(item);

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SettingsFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SettingsFragment.java
@@ -97,7 +97,7 @@ public class SettingsFragment extends BaseFragment implements SettingsViewModel.
 
     private void restart() {
         getActivity().finish();
-        MainActivity.start(getActivity());
+        startActivity(MainActivity.createIntent(getActivity()));
         getActivity().overridePendingTransition(0, 0);
     }
 


### PR DESCRIPTION
## Issue
none

## Overview (Required)
Two kinds of methods of calling Activity exist in the current project.
First, `start` method in ContributorsActivity, MainActivity, SearchActivity and SponsorsActivity.
Second, `createIntent` method in SessionDetailActivity and SessionFeedbackActivity.

These should be unified into either.
I think it is better to use `createIntent` because it can use `Intent#addFrag` and `startActivityForResult` later... 🤔 

## Links
none

## Screenshot
none
