### PR TITLE
Animate search result items when the result changes.

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SearchFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SearchFragment.java
@@ -204,6 +204,7 @@ public class SearchFragment extends BaseFragment implements SearchViewModel.Call
         SearchResultsAdapter(@NonNull Context context) {
             super(context);
             this.filteredList = new ArrayList<>();
+            setHasStableIds(true);
         }
 
         void setAllList(List<SearchResultViewModel> viewModels) {
@@ -266,6 +267,12 @@ public class SearchFragment extends BaseFragment implements SearchViewModel.Call
                     notifyDataSetChanged();
                 }
             };
+        }
+
+        @Override
+        public long getItemId(int position) {
+            SearchResultViewModel viewModel = getItem(position);
+            return viewModel.getSearchResultId();
         }
     }
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/SearchResultViewModel.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/SearchResultViewModel.java
@@ -3,7 +3,6 @@ package io.github.droidkaigi.confsched2017.viewmodel;
 import android.content.Context;
 import android.databinding.BaseObservable;
 import android.support.annotation.DrawableRes;
-import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.Spannable;
@@ -11,9 +10,6 @@ import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
 import android.text.style.TextAppearanceSpan;
 import android.view.View;
-
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 
 import io.github.droidkaigi.confsched2017.R;
 import io.github.droidkaigi.confsched2017.model.Session;
@@ -25,29 +21,17 @@ public class SearchResultViewModel extends BaseObservable implements ViewModel {
 
     private static final int ELLIPSIZE_LIMIT_COUNT = 30;
 
-    @Retention(RetentionPolicy.SOURCE)
-    @IntDef({TYPE_TITLE, TYPE_DESCRIPTION, TYPE_SPEAKER})
-    public @interface Type {
-    }
-
-    public static final int TYPE_TITLE = 1;
-
-    public static final int TYPE_DESCRIPTION = 2;
-
-    public static final int TYPE_SPEAKER = 3;
-
     private String sessionTitle;
 
     private String speakerImageUrl;
 
     private String text;
 
-    private int type;
+    private Type type;
+
+    private int searchResultId;
 
     private TextAppearanceSpan textAppearanceSpan;
-
-    @DrawableRes
-    private int iconResId;
 
     private boolean isMySession;
 
@@ -57,7 +41,7 @@ public class SearchResultViewModel extends BaseObservable implements ViewModel {
 
     private boolean shouldEllipsis;
 
-    private SearchResultViewModel(String text, @Type int type, Session session, Context context,
+    private SearchResultViewModel(String text, Type type, Session session, Context context,
             MySessionsRepository mySessionsRepository) {
         this.text = text;
         this.sessionTitle = session.title;
@@ -65,8 +49,8 @@ public class SearchResultViewModel extends BaseObservable implements ViewModel {
             this.speakerImageUrl = session.speaker.imageUrl;
         }
         this.type = type;
-        this.iconResId = getIconResId(type);
-        this.shouldEllipsis = type == TYPE_DESCRIPTION;
+        this.searchResultId = session.id * 10 + type.ordinal();
+        this.shouldEllipsis = type == Type.DESCRIPTION;
         this.session = session;
         this.textAppearanceSpan = new TextAppearanceSpan(context, R.style.SearchResultAppearance);
         this.isMySession = mySessionsRepository.isExist(session.id);
@@ -104,12 +88,12 @@ public class SearchResultViewModel extends BaseObservable implements ViewModel {
         return speakerImageUrl;
     }
 
+    @DrawableRes
     public int getIconResId() {
-        return iconResId;
+        return type.getIconResId();
     }
 
-    @Type
-    public int getType() {
+    public Type getType() {
         return type;
     }
 
@@ -152,36 +136,40 @@ public class SearchResultViewModel extends BaseObservable implements ViewModel {
     }
 
     public int getSearchResultId() {
-        return session.id * 10 + getType();
+        return searchResultId;
     }
 
-    @DrawableRes
-    private static int getIconResId(@Type int type) {
-        switch (type) {
-            case TYPE_DESCRIPTION:
-                return R.drawable.ic_description12_vector;
-            case TYPE_SPEAKER:
-                return R.drawable.ic_speaker_12_vector;
-            case TYPE_TITLE:
-                return R.drawable.ic_title_12_vector;
-        }
-        throw new IllegalStateException("unknown search result type " + type);
-    }
 
     static SearchResultViewModel createTitleType(@NonNull Session session, Context context,
             MySessionsRepository mySessionsRepository) {
-        return new SearchResultViewModel(session.title, TYPE_TITLE, session, context, mySessionsRepository);
+        return new SearchResultViewModel(session.title, Type.TITLE, session, context, mySessionsRepository);
     }
 
     static SearchResultViewModel createDescriptionType(@NonNull Session session, Context context,
             MySessionsRepository mySessionsRepository) {
-        return new SearchResultViewModel(session.desc, TYPE_DESCRIPTION, session, context, mySessionsRepository);
+        return new SearchResultViewModel(session.desc, Type.DESCRIPTION, session, context, mySessionsRepository);
     }
 
     static SearchResultViewModel createSpeakerType(@NonNull Session session, Context context,
             MySessionsRepository mySessionsRepository) {
-        return new SearchResultViewModel(session.speaker.name, TYPE_SPEAKER, session, context, mySessionsRepository);
+        return new SearchResultViewModel(session.speaker.name, Type.SPEAKER, session, context, mySessionsRepository);
     }
 
+    public enum Type {
+        TITLE(R.drawable.ic_title_12_vector),
+        DESCRIPTION(R.drawable.ic_description12_vector),
+        SPEAKER(R.drawable.ic_speaker_12_vector),
+        ;
 
+        private final @DrawableRes int iconResId;
+
+        Type(@DrawableRes int iconResId) {
+            this.iconResId = iconResId;
+        }
+
+        @DrawableRes
+        public int getIconResId() {
+            return iconResId;
+        }
+    }
 }

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -22,6 +22,7 @@
                 style="@style/BaseRecyclerView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:background="@color/white"
                 />
 
     </RelativeLayout>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -12,7 +12,6 @@
     <string name="session_detail">セッション詳細</string>
     <string name="speaker">スピーカー</string>
     <string name="session_time_range">%1$s〜%2$s (%3$d分)</string>
-    <string name="title">タイトル</string>
     <string name="description">内容</string>
     <string name="slide_and_video">資料＆動画</string>
     <string name="send_feedback">フィードバックを送る</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,7 +30,6 @@
     <string name="session_detail">Session Detail</string>
     <string name="speaker">Speaker</string>
     <string name="session_time_range">%1$s - %2$s (%3$d min)</string>
-    <string name="title">Title</string>
     <string name="description">Description</string>
     <string name="slide_and_video">Slide＆Video</string>
     <string name="send_feedback">Send feedback</string>


### PR DESCRIPTION
## Issue
- None

## Overview (Required)
- Animate search result items when the result changes. Please check screenshot gif.
- `RecyclerView.Adapter.setHasStableIds` is efficient for layout performance, and it's easy way to introduce item animation.
- For use above, SearchResultViewModel create id from session.id and which type of result (title, description, speaker).
- Set white color to background of the RecyclerView in search page. without this, the alpha animation looks not good.

This PR is just a suggestion, so close If you don't like it or don't need it.

## Links
- [RecyclerView.Adapter#setHasStableIds(boolean)](https://developer.android.com/reference/android/support/v7/widget/RecyclerView.Adapter.html#setHasStableIds(boolean))

## Screenshot
Before | After
:--: | :--:
<img src="https://cloud.githubusercontent.com/assets/949882/22855625/d36ee2ea-f0c6-11e6-817b-31a1bb984948.gif" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/949882/22855619/bcc7ff2c-f0c6-11e6-9b58-d66ae81a3730.gif" width="300" />
