### PR TITLE
Remove unnecessary test case.

### DIFF
--- a/app/src/test/java/io/github/droidkaigi/confsched2017/util/DateUtilTest.kt
+++ b/app/src/test/java/io/github/droidkaigi/confsched2017/util/DateUtilTest.kt
@@ -2,9 +2,11 @@ package io.github.droidkaigi.confsched2017.util
 
 import android.os.Build
 import com.taroid.knit.should
+import org.hamcrest.Matchers.instanceOf
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.fail
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.ExpectedException
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
@@ -12,25 +14,28 @@ import org.robolectric.annotation.Config
 import java.lang.reflect.InvocationTargetException
 import java.util.*
 
+
 /**
  * Created by KeishinYokomaku on 2017/01/17.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = intArrayOf(Build.VERSION_CODES.JELLY_BEAN_MR1, Build.VERSION_CODES.JELLY_BEAN_MR2))
 class DateUtilTest {
+
+    @Rule
+    @JvmField var thrown = ExpectedException.none()
+
     @Test
     @Throws(Exception::class)
     fun ctor() {
         // no instance allowed even if creating a new instance via reflection
         // because this is an utility!
-        try {
-            val ctor = DateUtil::class.java.getDeclaredConstructor()
-            ctor.isAccessible = true
-            ctor.newInstance()
-        } catch (e: InvocationTargetException) {
-            if (e.cause !is AssertionError)
-                fail()
-        }
+        thrown.expect(InvocationTargetException::class.java)
+        thrown.expectCause(instanceOf(AssertionError::class.java))
+
+        val ctor = DateUtil::class.java.getDeclaredConstructor()
+        ctor.isAccessible = true
+        ctor.newInstance()
     }
 
     @Test

--- a/app/src/test/java/io/github/droidkaigi/confsched2017/util/DateUtilTest.kt
+++ b/app/src/test/java/io/github/droidkaigi/confsched2017/util/DateUtilTest.kt
@@ -2,18 +2,13 @@ package io.github.droidkaigi.confsched2017.util
 
 import android.os.Build
 import com.taroid.knit.should
-import org.hamcrest.Matchers.instanceOf
 import org.junit.Assert.assertNotNull
-import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.ExpectedException
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
-import java.lang.reflect.InvocationTargetException
 import java.util.*
-
 
 /**
  * Created by KeishinYokomaku on 2017/01/17.
@@ -21,22 +16,6 @@ import java.util.*
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = intArrayOf(Build.VERSION_CODES.JELLY_BEAN_MR1, Build.VERSION_CODES.JELLY_BEAN_MR2))
 class DateUtilTest {
-
-    @Rule
-    @JvmField var thrown = ExpectedException.none()
-
-    @Test
-    @Throws(Exception::class)
-    fun ctor() {
-        // no instance allowed even if creating a new instance via reflection
-        // because this is an utility!
-        thrown.expect(InvocationTargetException::class.java)
-        thrown.expectCause(instanceOf(AssertionError::class.java))
-
-        val ctor = DateUtil::class.java.getDeclaredConstructor()
-        ctor.isAccessible = true
-        ctor.newInstance()
-    }
 
     @Test
     @Throws(Exception::class)


### PR DESCRIPTION
## Issue

None

## Overview (Required)

Even if the DateUtil constructor does not throw an exception the original test succeeds.
I introduced ExpectedException.

## Links

None

## Screenshot

None