### PR TITLE
Ignore click events on session header

### DIFF
--- a/app/src/main/res/layout/view_sessions_header_cell.xml
+++ b/app/src/main/res/layout/view_sessions_header_cell.xml
@@ -7,4 +7,5 @@
         android:gravity="center"
         android:textColor="@color/black"
         android:textStyle="bold"
+        android:clickable="true"
         />


### PR DESCRIPTION
Prevent session cell click event triggered unexpectedly by tapping on header view.

## Issue
- Nothing related

## Overview (Required)
- Just a quick minor UI fix: tapping on the header view of session list causes click event on the cell behind. I don't think that is intended behavior.
- I just found #180, so this change might be a short life, though.

## Links
- None

## Screenshot
Before | After
:--: | :--:
<img src="https://cloud.githubusercontent.com/assets/140446/22860302/126ae7e8-f13d-11e6-92ea-541ad5ae5375.gif" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/140446/22860303/13c5bc76-f13d-11e6-9a8c-3ad5e805cd82.gif" width="300" />
