### PR TITLE
[WIP] stop using updateConfiguration

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/util/LocaleUtil.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/util/LocaleUtil.java
@@ -1,8 +1,6 @@
 package io.github.droidkaigi.confsched2017.util;
 
 import android.content.Context;
-import android.content.res.Configuration;
-import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
 import android.text.TextUtils;
@@ -24,6 +22,7 @@ import timber.log.Timber;
 public class LocaleUtil {
 
     private static final Locale DEFAULT_LANG = Locale.ENGLISH;
+
     public static final List<Locale> SUPPORT_LANG = Arrays.asList(Locale.JAPANESE, Locale.ENGLISH);
 
     private static final String TAG = LocaleUtil.class.getSimpleName();
@@ -34,19 +33,8 @@ public class LocaleUtil {
         setLocale(context, getCurrentLanguageId(context));
     }
 
-    @SuppressWarnings("deprecation")
     public static void setLocale(Context context, String languageId) {
-        Configuration config = new Configuration();
         DefaultPrefs.get(context).putLanguageId(languageId);
-        Locale locale = new Locale(languageId);
-        Locale.setDefault(locale);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            config.setLocale(locale);
-        } else {
-            config.locale = locale;
-        }
-        // updateConfiguration, deprecated in API 25.
-        context.getResources().updateConfiguration(config, context.getResources().getDisplayMetrics());
     }
 
     public static String getCurrentLanguageId(Context context) {

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/BaseActivity.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/BaseActivity.java
@@ -3,6 +3,8 @@ package io.github.droidkaigi.confsched2017.view.activity;
 import com.tomoima.debot.Debot;
 
 import android.content.Context;
+import android.content.res.Configuration;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.IdRes;
 import android.support.annotation.LayoutRes;
@@ -13,12 +15,16 @@ import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.app.AppCompatDelegate;
 import android.support.v7.widget.Toolbar;
+import android.text.TextUtils;
 import android.view.KeyEvent;
 import android.view.MenuItem;
+
+import java.util.Locale;
 
 import io.github.droidkaigi.confsched2017.MainApplication;
 import io.github.droidkaigi.confsched2017.di.ActivityComponent;
 import io.github.droidkaigi.confsched2017.di.ActivityModule;
+import io.github.droidkaigi.confsched2017.util.LocaleUtil;
 import uk.co.chrisjenx.calligraphy.CalligraphyContextWrapper;
 
 public abstract class BaseActivity extends AppCompatActivity {
@@ -28,6 +34,7 @@ public abstract class BaseActivity extends AppCompatActivity {
     }
 
     private ActivityComponent activityComponent;
+
     private Debot debot;
 
     @NonNull
@@ -41,7 +48,8 @@ public abstract class BaseActivity extends AppCompatActivity {
 
     @Override
     protected void attachBaseContext(Context newBase) {
-        super.attachBaseContext(CalligraphyContextWrapper.wrap(newBase));
+        String currentLanguageId = LocaleUtil.getCurrentLanguageId(this);
+        super.attachBaseContext(CalligraphyContextWrapper.wrap(setUpLocale(newBase, currentLanguageId)));
     }
 
     @Override
@@ -97,6 +105,30 @@ public abstract class BaseActivity extends AppCompatActivity {
             bar.setDisplayShowHomeEnabled(true);
             bar.setDisplayShowTitleEnabled(true);
             bar.setHomeButtonEnabled(true);
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private Context setUpLocale(Context context, String language) {
+
+        if (TextUtils.isEmpty(language)) {
+            return context;
+        }
+
+        Configuration config = context.getResources().getConfiguration();
+
+        Locale locale = new Locale(language);
+        Locale.setDefault(locale);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            config.setLocale(locale);
+        } else {
+            config.locale = locale;
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            return context.createConfigurationContext(config);
+        } else {
+            context.getResources().updateConfiguration(config, context.getResources().getDisplayMetrics());
+            return context;
         }
     }
 }


### PR DESCRIPTION
## Issue
- #280 

## Overview (Required)
- SetUp Locale on attachBaseContext. And Pass that to CalligraphyContextWrapper.
- Remove SetUp Context from LocaleUtil.

## Links
- http://stackoverflow.com/questions/40221711/android-context-getresources-updateconfiguration-deprecated

## Screenshot
Before | After
:--: | :--:
<img src="https://cloud.githubusercontent.com/assets/3154259/22860623/daa7e798-f146-11e6-817a-16f1f0491bb5.png" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/3154259/22860628/efb2313e-f146-11e6-9e89-e52c66b27f93.png" width="300" />