### PR TITLE
Apply theme color for Dialog (Suggest)

### DIFF
--- a/app/src/main/res/values-v21/themes.xml
+++ b/app/src/main/res/values-v21/themes.xml
@@ -20,6 +20,8 @@
         <item name="android:statusBarColor">@android:color/transparent</item>
     </style>
 
-    <style name="DialogTheme" parent="Theme.AppCompat.Light.Dialog" />
+    <style name="DialogTheme" parent="Theme.AppCompat.Light.Dialog">
+        <item name="colorAccent">@color/theme</item>
+    </style>
 
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -37,6 +37,7 @@
 
     <style name="DialogTheme" parent="Theme.AppCompat.Light.Dialog">
         <!-- Avoid duplicate background beneath the dialog -->
+        <item name="colorAccent">@color/theme</item>
         <item name="android:windowBackground">@android:color/transparent</item>
     </style>
 


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- Apply theme color for Dialog
- Currently "AlertDialog" only used in "SettingsFragment"
  - This dialog radio button and cancel button are using the system default color (looks like a green)
- I suggest using a theme color

## Links
- https://material.io/guidelines/components/dialogs.html#dialogs-specs

> Dialog actions use system colors by default, but they should reflect your product's color palette. Use a contrasting color, such as the palette’s accent color, to distinguish dialog actions from dialog content.

Material design guidelines suggest using accent colors, but the accent color of the current theme is red. Since this looks like a "warning" color, I suggest a theme color.

If do not need the this PR, please close it!

## Screenshot
Before | After
:--: | :--:
<img src="https://cloud.githubusercontent.com/assets/1000715/22863652/97c8f87c-f187-11e6-817f-112ea935f864.png" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/1000715/22863656/a2bc4e96-f187-11e6-924e-5312048c7c42.png" width="300" />
