### PR TITLE
Replace for system framework's "AlertDialog" to "support-v7 AlertDialog"

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SettingsFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SettingsFragment.java
@@ -3,10 +3,10 @@ package io.github.droidkaigi.confsched2017.view.fragment;
 import com.annimon.stream.Collectors;
 import com.annimon.stream.Stream;
 
-import android.app.AlertDialog;
 import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.v7.app.AlertDialog;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -80,7 +80,7 @@ public class SettingsFragment extends BaseFragment implements SettingsViewModel.
         Timber.tag(TAG).d("current language_id index: %s", defaultItem);
 
         String[] items = languages.toArray(new String[languages.size()]);
-        new AlertDialog.Builder(getActivity())
+        new AlertDialog.Builder(getActivity(), R.style.DialogTheme)
                 .setTitle(R.string.settings_language)
                 .setSingleChoiceItems(items, defaultItem, (dialog, which) -> {
                     String selectedLanguageId = languageIds.get(which);

--- a/app/src/main/res/values-v21/themes.xml
+++ b/app/src/main/res/values-v21/themes.xml
@@ -20,8 +20,4 @@
         <item name="android:statusBarColor">@android:color/transparent</item>
     </style>
 
-    <style name="DialogTheme" parent="Theme.AppCompat.Light.Dialog">
-        <item name="colorAccent">@color/theme</item>
-    </style>
-
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -36,9 +36,7 @@
     </style>
 
     <style name="DialogTheme" parent="Theme.AppCompat.Light.Dialog">
-        <!-- Avoid duplicate background beneath the dialog -->
         <item name="colorAccent">@color/theme</item>
-        <item name="android:windowBackground">@android:color/transparent</item>
     </style>
 
     <style name="AppTheme.ColoredStatusBar">


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- Related #324 
  - Sorry it has become an separate PR
- Currently to using the system framework's AlertDialog widget in change language dialog
  - This widget is NOT provide Material Design dialog for under Android 4.4
- Replace to support-v7 version's AlertDialog
- If don't need the this PR, please close it

## Links
- none

## Screenshot

Before (4.1) | After (4.1) | Before (4.4) | After (4.4) | Before (7.1) | After (7.1)
:--: | :--: | :--: | :--: | :--: | :--:
<img src="https://cloud.githubusercontent.com/assets/1000715/22864120/ec0df44e-f18e-11e6-8c4e-63956af16ee3.png" width="100" /> | <img src="https://cloud.githubusercontent.com/assets/1000715/22864121/eeb25a50-f18e-11e6-887c-3ea27cd1bcd4.png" width="100" /> | <img src="https://cloud.githubusercontent.com/assets/1000715/22864138/3159ab06-f18f-11e6-8dd2-880965dffdbb.png" width="100" /> | <img src="https://cloud.githubusercontent.com/assets/1000715/22864139/33161d30-f18f-11e6-83f8-f73cc91bc4aa.png" width="100" /> | <img src="https://cloud.githubusercontent.com/assets/1000715/22864136/2afa1d4a-f18f-11e6-9a26-756ae0767249.png" width="100" /> | <img src="https://cloud.githubusercontent.com/assets/1000715/22864137/2e1694f4-f18f-11e6-9577-a92856c1ebc8.png" width="100" />
