### PR TITLE
Remove unnecessary packagingOptions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -124,10 +124,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    packagingOptions {
-        exclude 'LICENSE.txt'
-    }
-
     jacoco {
         version "0.7.7.201606060606"
     }


### PR DESCRIPTION
## Issue
-

## Overview (Required)
~~There are 2 packagingOptions in `app/build.gradle`. Let's combine them.~~

~~BTW, do we really need `exclude 'LICENSE.txt'`???~~ 

Remove unnecessary `packagingOptions`

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
