### PR TITLE
Separate the logic for animating the ParticleView into SplashFragment.

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/SplashActivity.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/SplashActivity.java
@@ -8,10 +8,6 @@ import android.os.Handler;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-
 import io.github.droidkaigi.confsched2017.R;
 import io.github.droidkaigi.confsched2017.databinding.ActivitySplashBinding;
 
@@ -20,10 +16,8 @@ public class SplashActivity extends AppCompatActivity {
     private static final String TAG = SplashActivity.class.getSimpleName();
 
     private ActivitySplashBinding binding;
-    private final ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
     private final Handler handler = new Handler();
     private final Runnable moveActivityRunnable = () -> {
-        scheduledExecutorService.shutdown();
         startActivity(new Intent(SplashActivity.this, MainActivity.class));
     };
 
@@ -36,13 +30,11 @@ public class SplashActivity extends AppCompatActivity {
             findViewById(android.R.id.content).setSystemUiVisibility(
                     View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN | View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
         }
+    }
 
-        scheduledExecutorService.scheduleAtFixedRate(
-                () -> binding.particleAnimationView.postInvalidate(),
-                0L,
-                40L,
-                TimeUnit.MILLISECONDS);
-
+    @Override
+    protected void onStart() {
+        super.onStart();
         handler.postDelayed(moveActivityRunnable, 3000);
     }
 

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SplashFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SplashFragment.java
@@ -1,0 +1,45 @@
+package io.github.droidkaigi.confsched2017.view.fragment;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import io.github.droidkaigi.confsched2017.databinding.FragmentSplashBinding;
+
+/**
+ * Show splash screen, responsible for handling ParticleView animation.
+ */
+public class SplashFragment extends Fragment {
+    public static final String TAG = SplashFragment.class.getSimpleName();
+
+    private FragmentSplashBinding binding;
+
+    private final ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+
+    @Nullable
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        binding = FragmentSplashBinding.inflate(inflater, container, false);
+
+        scheduledExecutorService.scheduleAtFixedRate(
+                () -> binding.particleAnimationView.postInvalidate(),
+                0L,
+                40L,
+                TimeUnit.MILLISECONDS);
+
+        return binding.getRoot();
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        scheduledExecutorService.shutdown();
+    }
+}

--- a/app/src/main/res/layout/activity_splash.xml
+++ b/app/src/main/res/layout/activity_splash.xml
@@ -1,34 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <RelativeLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
-
-        <io.github.droidkaigi.confsched2017.view.customview.ParticlesAnimationView
-            android:id="@+id/particle_animation_view"
+    <FrameLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_centerInParent="true" />
-
-        <TextView
-            android:id="@+id/title_logo"
-            fontPath="@string/font_noto_cjk_medium"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
-            android:layout_margin="@dimen/space_32dp"
-            android:background="@drawable/bg_splash_title"
-            android:gravity="center"
-            android:padding="@dimen/space_16dp"
-            android:text="@string/splash_title"
-            android:textColor="@color/white"
-            android:textScaleX="1.15"
-            android:textSize="32sp"
-            android:textStyle="bold" />
-
-    </RelativeLayout>
+            >
+        <fragment
+                android:id="@+id/fragment_splash"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:name="io.github.droidkaigi.confsched2017.view.fragment.SplashFragment"
+                />
+    </FrameLayout>
 
 </layout>

--- a/app/src/main/res/layout/fragment_splash.xml
+++ b/app/src/main/res/layout/fragment_splash.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <io.github.droidkaigi.confsched2017.view.customview.ParticlesAnimationView
+            android:id="@+id/particle_animation_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_centerInParent="true" />
+
+        <TextView
+            android:id="@+id/title_logo"
+            fontPath="@string/font_noto_cjk_medium"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:layout_margin="@dimen/space_32dp"
+            android:background="@drawable/bg_splash_title"
+            android:gravity="center"
+            android:padding="@dimen/space_16dp"
+            android:text="@string/splash_title"
+            android:textColor="@color/white"
+            android:textScaleX="1.15"
+            android:textSize="32sp"
+            android:textStyle="bold" />
+
+    </RelativeLayout>
+
+</layout>


### PR DESCRIPTION
## Overview (Required)

Currently SplashActivity has 2 responsibility:

* animating ParticleView
* start MainActivity with 3 seconds delay.

I think it would be more useful if the logic of animation is capsulized in a Fragment.
This Pull Request provides `SplashFragment` for handling the ParticleView, and makes SplashActivity simpler.

## Links
-

## Screenshot

not changed. Just a refactoring :)