### PR TITLE
Apply contributors columns to landscape and tablets

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/ContributorsFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/ContributorsFragment.java
@@ -4,6 +4,7 @@ import com.annimon.stream.Optional;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.databinding.ObservableList;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -23,13 +24,10 @@ import io.github.droidkaigi.confsched2017.view.customview.BindingHolder;
 import io.github.droidkaigi.confsched2017.view.helper.IntentHelper;
 import io.github.droidkaigi.confsched2017.viewmodel.ContributorViewModel;
 import io.github.droidkaigi.confsched2017.viewmodel.ContributorsViewModel;
-import io.reactivex.disposables.CompositeDisposable;
 
 public class ContributorsFragment extends BaseFragment implements ContributorsViewModel.Callback {
 
     public static final String TAG = ContributorsFragment.class.getSimpleName();
-
-    private static final int COLUMN_COUNT = 3;
 
     @Inject
     ContributorsViewModel viewModel;
@@ -77,13 +75,23 @@ public class ContributorsFragment extends BaseFragment implements ContributorsVi
     private void initView() {
         adapter = new Adapter(getContext(), viewModel.getContributorViewModels());
         binding.recyclerView.setAdapter(adapter);
-        binding.recyclerView.setLayoutManager(new GridLayoutManager(getContext(), COLUMN_COUNT));
+        binding.recyclerView.setLayoutManager(new GridLayoutManager(getContext(), getColumnCount()));
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        ((GridLayoutManager) binding.recyclerView.getLayoutManager()).setSpanCount(getColumnCount());
     }
 
     @Override
     public void onClickContributor(String htmlUrl) {
         Optional<Intent> intentOptional = IntentHelper.buildActionViewIntent(getContext(), htmlUrl);
         intentOptional.ifPresent(this::startActivity);
+    }
+
+    private int getColumnCount() {
+        return getResources().getInteger(R.integer.contributors_columns);
     }
 
     private static class Adapter

--- a/app/src/main/res/values-land/integers.xml
+++ b/app/src/main/res/values-land/integers.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <integer name="contributors_columns">6</integer>
+
+</resources>

--- a/app/src/main/res/values-sw600dp/integers.xml
+++ b/app/src/main/res/values-sw600dp/integers.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <integer name="contributors_columns">6</integer>
+
+</resources>

--- a/app/src/main/res/values/integers.xml
+++ b/app/src/main/res/values/integers.xml
@@ -6,4 +6,6 @@
 
     <integer name="fab_vector_animation_mills">200</integer>
 
+    <integer name="contributors_columns">3</integer>
+
 </resources>


### PR DESCRIPTION
## Issue
none

## Overview (Required)
- I changed the contributors columns count from 3 to 6 when the device is landscape or tablet.

## Links
- https://developer.android.com/guide/practices/screens_support.html

## Screenshot
landscape

Before | After
:--: | :--:
<img src="https://cloud.githubusercontent.com/assets/11440952/22890825/d095c760-f250-11e6-9772-983d47164be1.png" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/11440952/22890832/d5deed28-f250-11e6-8a93-580f76a5e8c1.png" width="300" />

tablet

Before | After
:--: | :--:
<img src="https://cloud.githubusercontent.com/assets/11440952/22890839/dbe4907e-f250-11e6-85c8-7d2d2247aca3.png" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/11440952/22890851/e2bac5da-f250-11e6-8b41-5cc59d85a3e8.png" width="300" />