### PR TITLE
Stop restarting a process for service recreation

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/service/DebugOverlayService.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/service/DebugOverlayService.java
@@ -58,11 +58,7 @@ public class DebugOverlayService extends BaseService {
     @Override
     public int onStartCommand(Intent intent, @ServiceFlags int flags, int startId) {
         Timber.d("onStartCommand");
-        if (!SettingsUtil.canDrawOverlays(this)) {
-            stopSelf();
-            return START_NOT_STICKY;
-        }
-        return super.onStartCommand(intent, flags, startId);
+        return START_NOT_STICKY; // no need to restart a process
     }
 
     @Override


### PR DESCRIPTION
- DebugOverlayService should live along with an app process and never be restarted again automatically after its death, causing unnecessary process restart 😭