### PR TITLE
add reviewdog configuration

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,7 @@ machine:
     JAVA_OPTS: "-Xms512m -Xmx1024m"
     GRADLE_OPTS: '-Dorg.gradle.parallel=false -Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-Xmx1560m -XX:+HeapDumpOnOutOfMemoryError"'
     TERM: dumb
+    REVIEWDOG_VERSION: 0.9.3
 
 dependencies:
   pre:
@@ -16,13 +17,14 @@ dependencies:
     - $ANDROID_HOME/tools/bin/sdkmanager "platform-tools" "extras;android;m2repository" "extras;google;m2repository"
     - $ANDROID_HOME/tools/bin/sdkmanager "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.0-beta5"
     - $ANDROID_HOME/tools/bin/sdkmanager "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta5"
+    - curl -fSL https://github.com/haya14busa/reviewdog/releases/download/$REVIEWDOG_VERSION/reviewdog_linux_amd64 -o reviewdog && chmod +x ./reviewdog
   override:
     - ./gradlew app:dependencies
 
 test:
   override:
     - ./gradlew assembleProductionDebug
-    - ./gradlew lint
+    - "./gradlew lint 2>&1 | ./reviewdog -efm='%f:%l: %m' -name='Android Lint' -ci='circle-ci'"
     - ./gradlew checkLicenses
     - ./gradlew jacocoTestReportDevelop
     - find . -name app*debug.apk -exec cp {} $CIRCLE_ARTIFACTS/ \;


### PR DESCRIPTION
## Issue
- #266

## Overview (Required)
- Introducing [reviewdog](https://github.com/haya14busa/reviewdog), lint notifier.
- As stated in #266, you need a GitHub personal access token to use reviewdog.
- With this setup, reviewdog will swallow all stdout lint result. If you want to check actual result on CircleCI's build page, I'm going update PR to use xml output instead.

## Links
- https://github.com/haya14busa/reviewdog
- https://circleci.com/docs/fork-pr-builds/#security-implications-of-running-builds-for-pull-requests-from-forks

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
