### PR TITLE
Start splash more quickly

### DIFF
--- a/app/src/main/res/drawable/bg_splash.xml
+++ b/app/src/main/res/drawable/bg_splash.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item>
+        <shape android:shape="rectangle">
+            <gradient
+                    android:angle="45"
+                    android:centerColor="@color/dark_purple"
+                    android:centerX="0.6"
+                    android:endColor="@color/dark_purple_alpha_0"
+                    android:startColor="@color/dark_light_green"
+                    android:type="linear"
+                    />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <gradient
+                    android:angle="45"
+                    android:centerColor="@color/dark_purple"
+                    android:centerX="0.6"
+                    android:endColor="@color/dark_pink"
+                    android:startColor="@color/dark_purple_alpha_0"
+                    android:type="linear"
+                    />
+        </shape>
+    </item>
+</layer-list>

--- a/app/src/main/res/values-v19/themes.xml
+++ b/app/src/main/res/values-v19/themes.xml
@@ -3,5 +3,6 @@
     <style name="AppTheme.NoActionBar.Splash" parent="AppTheme.NoActionBar">
         <item name="android:windowTranslucentStatus">true</item>
         <item name="android:windowTranslucentNavigation">true</item>
+        <item name="android:background">@drawable/bg_splash</item>
     </style>
 </resources>

--- a/app/src/main/res/values-v21/themes.xml
+++ b/app/src/main/res/values-v21/themes.xml
@@ -11,6 +11,7 @@
     <style name="AppTheme.NoActionBar.Splash" parent="AppTheme.NoActionBar">
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:windowTranslucentNavigation">true</item>
+        <item name="android:background">@drawable/bg_splash</item>
     </style>
 
     <style name="AppTheme.NoActionBar">

--- a/app/src/main/res/values/colors_palette.xml
+++ b/app/src/main/res/values/colors_palette.xml
@@ -31,8 +31,8 @@
     <color name="yellow_alpha_15">#26ffeb3b</color>
 
     <color name="purple_alpha_30">#2658037C</color>
-
     <color name="purple_alpha_50">#8058037C</color>
+    <color name="dark_purple_alpha_0">#006c78b6</color>
     <color name="ultra_light_blue_alpha_50">#8089ecef</color>
     <color name="light_blue_alpha_50">#804DD0E1</color>
     <color name="light_green_alpha_50">#80A3D68A</color>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -46,6 +46,7 @@
     </style>
 
     <style name="AppTheme.NoActionBar.Splash" parent="AppTheme.NoActionBar">
+        <item name="android:background">@drawable/bg_splash</item>
     </style>
 
     <style name="AppTheme.NoActionBar">


### PR DESCRIPTION
## Issue
none

## Overview (Required)
A white screen is displayed until the inflation of Splash layout is completed. "background" attribute of the theme can solve this problem.
I created a splash-like drawable with xml, but it's not perfect. 😢 Please close this PR if you feel unnecessary 🙇 

## Links
none

## Screenshot
Before | After
:--: | :--:
<img src="https://cloud.githubusercontent.com/assets/11440952/22943033/486c23d6-f32f-11e6-8312-fa26c5e2f4e0.gif" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/11440952/22943032/486a8e72-f32f-11e6-8976-51e4e6b7c2e1.gif" width="300" />
