### PR TITLE
Implement a retry button for when contributors load failed

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/ContributorsFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/ContributorsFragment.java
@@ -9,6 +9,7 @@ import android.databinding.ObservableList;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.design.widget.Snackbar;
 import android.support.v7.widget.GridLayoutManager;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -88,6 +89,13 @@ public class ContributorsFragment extends BaseFragment implements ContributorsVi
     public void onClickContributor(String htmlUrl) {
         Optional<Intent> intentOptional = IntentHelper.buildActionViewIntent(getContext(), htmlUrl);
         intentOptional.ifPresent(this::startActivity);
+    }
+
+    @Override
+    public void showError(String text) {
+        Snackbar.make(binding.getRoot(), text, Snackbar.LENGTH_INDEFINITE)
+                .setAction(R.string.retry, v -> viewModel.retry())
+                .show();
     }
 
     private int getColumnCount() {

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/ContributorsFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/ContributorsFragment.java
@@ -9,7 +9,9 @@ import android.databinding.ObservableList;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.StringRes;
 import android.support.design.widget.Snackbar;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.GridLayoutManager;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -92,9 +94,10 @@ public class ContributorsFragment extends BaseFragment implements ContributorsVi
     }
 
     @Override
-    public void showError(String text) {
-        Snackbar.make(binding.getRoot(), text, Snackbar.LENGTH_INDEFINITE)
+    public void showError(@StringRes int resId) {
+        Snackbar.make(binding.getRoot(), resId, Snackbar.LENGTH_INDEFINITE)
                 .setAction(R.string.retry, v -> viewModel.retry())
+                .setActionTextColor(ContextCompat.getColor(getActivity(), R.color.white))
                 .show();
     }
 

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/ContributorsViewModel.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/ContributorsViewModel.java
@@ -43,8 +43,6 @@ public final class ContributorsViewModel extends BaseObservable implements ViewM
 
     private int loadingVisibility;
 
-    private int retryVisibility;
-
     private boolean refreshing;
 
     @Nullable
@@ -91,16 +89,6 @@ public final class ContributorsViewModel extends BaseObservable implements ViewM
     }
 
     @Bindable
-    public int getRetryVisibility() {
-        return retryVisibility;
-    }
-
-    private void setRetryVisibility(int visibility) {
-        this.retryVisibility = visibility;
-        notifyPropertyChanged(BR.retryVisibility);
-    }
-
-    @Bindable
     public boolean getRefreshing() {
         return refreshing;
     }
@@ -114,7 +102,7 @@ public final class ContributorsViewModel extends BaseObservable implements ViewM
         loadContributors(true);
     }
 
-    public void onClickRetry(@SuppressWarnings("unused") View view) {
+    public void retry() {
         loadContributors(false);
     }
 
@@ -128,7 +116,6 @@ public final class ContributorsViewModel extends BaseObservable implements ViewM
         } else {
             setLoadingVisibility(View.VISIBLE);
         }
-        setRetryVisibility(View.GONE);
 
         Disposable disposable = contributorsRepository.findAll()
                 .map(contributors -> Stream.of(contributors).map(contributor -> {
@@ -142,7 +129,9 @@ public final class ContributorsViewModel extends BaseObservable implements ViewM
                         this::renderContributors,
                         throwable -> {
                             setLoadingVisibility(View.GONE);
-                            setRetryVisibility(viewModels.isEmpty() ? View.VISIBLE : View.GONE);
+                            if (callback != null) {
+                                callback.showError("Failed to show contributors.");
+                            }
                             Timber.tag(TAG).e(throwable, "Failed to show contributors.");
                         });
         compositeDisposable.add(disposable);
@@ -163,5 +152,7 @@ public final class ContributorsViewModel extends BaseObservable implements ViewM
     public interface Callback {
 
         void onClickContributor(String htmlUrl);
+
+        void showError(String text);
     }
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/ContributorsViewModel.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/ContributorsViewModel.java
@@ -9,6 +9,7 @@ import android.databinding.ObservableArrayList;
 import android.databinding.ObservableList;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.StringRes;
 import android.view.View;
 
 import java.util.List;
@@ -130,7 +131,7 @@ public final class ContributorsViewModel extends BaseObservable implements ViewM
                         throwable -> {
                             setLoadingVisibility(View.GONE);
                             if (callback != null) {
-                                callback.showError("Failed to show contributors.");
+                                callback.showError(R.string.contributors_load_failed);
                             }
                             Timber.tag(TAG).e(throwable, "Failed to show contributors.");
                         });
@@ -153,6 +154,6 @@ public final class ContributorsViewModel extends BaseObservable implements ViewM
 
         void onClickContributor(String htmlUrl);
 
-        void showError(String text);
+        void showError(@StringRes int textRes);
     }
 }

--- a/app/src/main/res/layout/fragment_contributors.xml
+++ b/app/src/main/res/layout/fragment_contributors.xml
@@ -33,20 +33,22 @@
 
         </android.support.v4.widget.SwipeRefreshLayout>
 
-        <FrameLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:background="@color/white"
+        <ProgressBar
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:visibility="@{viewModel.loadingVisibility}"
-            tools:visibility="gone">
+            android:layout_gravity="center"
+            />
 
-            <ProgressBar
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                />
-
-        </FrameLayout>
+        <Button
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:onClick="@{viewModel::onClickRetry}"
+            android:text="@string/retry"
+            android:textColor="@color/white"
+            android:visibility="@{viewModel.retryVisibility}"
+            />
 
     </FrameLayout>
 

--- a/app/src/main/res/layout/fragment_contributors.xml
+++ b/app/src/main/res/layout/fragment_contributors.xml
@@ -40,16 +40,6 @@
             android:layout_gravity="center"
             />
 
-        <Button
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:onClick="@{viewModel::onClickRetry}"
-            android:text="@string/retry"
-            android:textColor="@color/white"
-            android:visibility="@{viewModel.retryVisibility}"
-            />
-
     </FrameLayout>
 
 </layout>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -42,6 +42,7 @@
     <!-- Contributors -->
     <string name="contributors">コントリビュータ</string>
     <string name="contributors_people">(%1$d人)</string>
+    <string name="contributors_load_failed">コントリビュータを表示できませんでした。</string>
     <!-- Help Translate -->
     <string name="help_translate">翻訳のお手伝い</string>
     <!-- Licenses -->

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -7,6 +7,7 @@
     <string name="map">地図</string>
     <string name="information">情報</string>
     <string name="settings">設定</string>
+    <string name="retry">再読み込み</string>
     <!-- Sessions -->
     <string name="session_minutes">(%1$d分)</string>
     <string name="session_detail">セッション詳細</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,6 +23,7 @@
     <string name="map">Map</string>
     <string name="information">Information</string>
     <string name="settings">Settings</string>
+    <string name="retry">retry</string>
 
     <!-- Splash -->
     <string name="splash_title">DroidKaigi 2017</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,7 +23,7 @@
     <string name="map">Map</string>
     <string name="information">Information</string>
     <string name="settings">Settings</string>
-    <string name="retry">retry</string>
+    <string name="retry">Retry</string>
 
     <!-- Splash -->
     <string name="splash_title">DroidKaigi 2017</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,6 +83,7 @@
     <string name="contributors">Contributors</string>
     <string name="contributors_people">(%1$d people)</string>
     <string name="contributors_open_repository">Repository</string>
+    <string name="contributors_load_failed">Failed to show contributors.</string>
 
     <string name="help_translate">Help Translate</string>
 


### PR DESCRIPTION
## Issue
none

## Overview (Required)
Loading will result in an error if you do not have a cache and can't connect to the Internet, but nothing changes on the screen.
In that case, I think that the application needs an approach such as showing a retry button.

I implemented it on ContributorsFragment for the time being, I think that the similar processing is necessary on other screens.
But since they are numerous, we will create an Issue if necessary 🙇 

## Links
none

## Screenshot
Before | After
:--: | :--:
<img src="https://cloud.githubusercontent.com/assets/11440952/22984163/de57fe20-f3e7-11e6-9626-4579fe90d83e.gif" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/11440952/22984162/de52c734-f3e7-11e6-8288-75a725e7b3a6.gif" width="300" />
