### PR TITLE
Use match_parent for my sessions recycler view.

### DIFF
--- a/app/src/main/res/layout/fragment_my_sessions.xml
+++ b/app/src/main/res/layout/fragment_my_sessions.xml
@@ -18,7 +18,7 @@
                 android:id="@+id/recycler_view"
                 style="@style/BaseRecyclerView"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                android:layout_height="match_parent"
                 android:background="@color/white"
                 android:visibility="@{viewModel.recyclerViewVisibility}"
                 />


### PR DESCRIPTION
## Issue
- #353 

## Overview (Required)
- Use `match_parent` instead `wrap_content` for RecyclerView which has fixed size.

## Links
- None

## Screenshot
Before | After
:--: | :--:
<img src="https://cloud.githubusercontent.com/assets/949882/23032145/e140a982-f4b6-11e6-8364-ee93305ade05.png" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/949882/23032167/ef9898dc-f4b6-11e6-94ee-9b69f98109b4.png" width="300" />



