### PR TITLE
Update Debot

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -223,8 +223,8 @@ dependencies {
     debugCompile 'com.squareup.leakcanary:leakcanary-android:1.5'
     releaseCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.5'
     testCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.5'
-    debugCompile 'com.tomoima.debot:debot:2.0.0'
-    releaseCompile 'com.tomoima.debot:debot-no-op:2.0.0'
+    debugCompile 'com.tomoima.debot:debot:2.0.2'
+    releaseCompile 'com.tomoima.debot:debot-no-op:2.0.2'
 
     // Test
     testCompile 'junit:junit:4.12'

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -146,6 +146,7 @@
                     >
 
                 <TextView
+                        android:id="@+id/developer_menu_title"
                         style="@style/TextSubheading"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
@@ -153,6 +154,15 @@
                         android:textColor="?attr/colorPrimary"
                         />
 
+                <TextView
+                        android:id="@+id/developer_menu_tips"
+                        style="@style/SettingDescriptionText"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_below="@id/developer_menu_title"
+                        android:layout_marginTop="@dimen/space_8dp"
+                        android:text="@string/settings_developer_tips"
+                        />
             </RelativeLayout>
 
             <io.github.droidkaigi.confsched2017.view.customview.SettingSwitchRowView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,6 +59,7 @@
     <string name="settings_local_time">Show local time</string>
     <string name="settings_local_time_description">Use your local time instead of the conference\’s local time.</string>
     <string name="settings_developer_group">Developer menu</string>
+    <string name="settings_developer_tips">Tips: To show Debug menu, press Command + M for emulators or shake your device.(Only works for Debug build)</string>
     <string name="settings_debug_overlay_view">Debug Overlay View</string>
     <string name="settings_debug_overlay_view_description">Choose whether to show Debug Overlay View.</string>
     <string name="settings_debug_overlay_view_toast">Before enabling this setting, grant draw over other apps permission.</string>


### PR DESCRIPTION
## Issue
- fix for issue #254 (the app crashes when saving menu with "Do not keep Activities" mode )

## Overview (Required)
- Issue fixed with the latest version of Debot
- However, there's is another crash caused by two-way view. 
- Also added a description of Debug menu on the setting screen

## Screenshot
Before | After
:--: | :--:
<img src="https://cloud.githubusercontent.com/assets/6277118/23056035/10c0ab44-f49e-11e6-9e95-366c87619479.png" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/6277118/23056036/10c2d84c-f49e-11e6-84a2-2bbef6f0bd90.png" width="300" />

