### PR TITLE
Add page finishing function when over scrolled to SessionDetailActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,7 +44,7 @@
                 android:exported="false"
                 android:label="@string/session_detail"
                 android:parentActivityName=".view.activity.MainActivity"
-                android:theme="@style/AppTheme.NoActionBar"
+                android:theme="@style/AppTheme.Translucent.Half"
                 />
 
         <activity

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/customview/OverScrollLayout.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/customview/OverScrollLayout.java
@@ -1,0 +1,171 @@
+package io.github.droidkaigi.confsched2017.view.customview;
+
+import android.animation.Animator;
+import android.content.Context;
+import android.databinding.BindingMethod;
+import android.databinding.BindingMethods;
+import android.graphics.PointF;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.design.widget.AppBarLayout;
+import android.support.design.widget.CoordinatorLayout;
+import android.support.v4.widget.NestedScrollView;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.animation.AccelerateDecelerateInterpolator;
+
+import io.github.droidkaigi.confsched2017.R;
+
+
+@BindingMethods({
+        @BindingMethod(type = OverScrollLayout.class, attribute = "onOverScroll", method = "setOverScrollListener")
+})
+public class OverScrollLayout extends CoordinatorLayout {
+
+    private static final float OVER_SCROLL_THRESHOLD = 0.20f;
+
+    private static final int RESTORE_ANIM_DURATION = 100;
+
+    private static final float MINIMUM_OVER_SCROLL_SCALE = 0.99f;
+
+    private int overScrollThreshold;
+
+    private PointF originalLocation = new PointF();
+
+    private int originalHeight;
+
+    private OnOverScrollListener overScrollListener;
+
+    public OverScrollLayout(Context context) {
+        super(context);
+    }
+
+    public OverScrollLayout(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public OverScrollLayout(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @Override
+    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+        super.onLayout(changed, left, top, right, bottom);
+        originalLocation.set(left, top);
+        originalHeight = bottom - top;
+        overScrollThreshold = (int) (originalHeight * OVER_SCROLL_THRESHOLD);
+    }
+
+    @Override
+    public void onNestedPreScroll(View target, int dx, int dy, int[] consumed) {
+        if (getY() != originalLocation.y) {
+            float scale =
+                    Math.max(MINIMUM_OVER_SCROLL_SCALE,
+                            1 - (Math.abs(getY()) / overScrollThreshold) * (1 - MINIMUM_OVER_SCROLL_SCALE));
+            setScaleX(scale);
+            setScaleY(scale);
+            translationY(-dy);
+            consumed[1] = dy;
+        } else {
+            super.onNestedPreScroll(target, dx, dy, consumed);
+        }
+    }
+
+    @Override
+    public void onNestedScroll(View target, int dxConsumed, int dyConsumed, int dxUnconsumed, int dyUnconsumed) {
+        super.onNestedScroll(target, dxConsumed, dyConsumed, dxUnconsumed, dyUnconsumed);
+        AppBarLayout appBarLayout = null;
+        boolean scrollTop = false;
+        boolean scrollEnd = false;
+        for (int i = 0; i < getChildCount(); i++) {
+            View view = getChildAt(i);
+            if (view instanceof AppBarLayout) {
+                appBarLayout = (AppBarLayout) view;
+                continue;
+            }
+            if (view instanceof NestedScrollView) {
+                scrollTop = !view.canScrollVertically(-1);
+                scrollEnd = !view.canScrollVertically(1);
+            }
+        }
+
+        if (appBarLayout == null || scrollTop && dyUnconsumed < 0 && isAppBarExpanded(appBarLayout)) {
+            translationY(-dyUnconsumed);
+        }
+        if (appBarLayout == null || scrollEnd && dyUnconsumed > 0 && isAppBarCollapsed(appBarLayout)) {
+            translationY(-dyUnconsumed);
+        }
+    }
+
+    @Override
+    public boolean onNestedPreFling(View target, float velocityX, float velocityY) {
+        return getY() != originalLocation.y || super.onNestedPreFling(target, velocityX, velocityY);
+    }
+
+    @Override
+    public void onStopNestedScroll(View target) {
+        super.onStopNestedScroll(target);
+        if (Math.abs(getY()) > overScrollThreshold && overScrollListener != null) {
+            float yTranslation;
+            if (getY() > 0) {
+                yTranslation = originalLocation.y + originalHeight;
+            } else {
+                yTranslation = originalLocation.y - originalHeight;
+            }
+            animate()
+                    .setDuration(getContext().getResources().getInteger(R.integer.activity_transition_mills))
+                    .setInterpolator(new AccelerateDecelerateInterpolator())
+                    .alpha(0)
+                    .translationY(yTranslation)
+                    .setListener(new Animator.AnimatorListener() {
+                        @Override
+                        public void onAnimationStart(Animator animation) {
+                        }
+
+                        @Override
+                        public void onAnimationEnd(Animator animation) {
+                            overScrollListener.onOverScroll();
+
+                        }
+
+                        @Override
+                        public void onAnimationCancel(Animator animation) {
+                        }
+
+                        @Override
+                        public void onAnimationRepeat(Animator animation) {
+                        }
+                    });
+            return;
+        }
+        if (getY() != originalLocation.y) {
+            animate()
+                    .setDuration(RESTORE_ANIM_DURATION)
+                    .setInterpolator(new AccelerateDecelerateInterpolator())
+                    .translationY(originalLocation.y)
+                    .scaleX(1)
+                    .scaleY(1);
+        }
+    }
+
+    private void translationY(float dy) {
+        setY(getY() + dy * 0.5f);
+    }
+
+    private boolean isAppBarExpanded(@NonNull AppBarLayout appBarLayout) {
+        return appBarLayout.getHeight() == appBarLayout.getBottom();
+    }
+
+    private boolean isAppBarCollapsed(@NonNull AppBarLayout appBarLayout) {
+        return Math.abs(appBarLayout.getY()) == appBarLayout.getTotalScrollRange();
+    }
+
+    public void setOverScrollListener(@Nullable OnOverScrollListener listener) {
+        this.overScrollListener = listener;
+    }
+
+    public interface OnOverScrollListener {
+
+        void onOverScroll();
+    }
+}

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SessionDetailFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SessionDetailFragment.java
@@ -23,7 +23,6 @@ import javax.inject.Inject;
 
 import io.github.droidkaigi.confsched2017.R;
 import io.github.droidkaigi.confsched2017.databinding.FragmentSessionDetailBinding;
-import io.github.droidkaigi.confsched2017.view.activity.SessionFeedbackActivity;
 import io.github.droidkaigi.confsched2017.view.helper.AnimationHelper;
 import io.github.droidkaigi.confsched2017.viewmodel.SessionDetailViewModel;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -169,5 +168,11 @@ public class SessionDetailFragment extends BaseFragment implements SessionDetail
                 .setAction(actionTextId, v -> binding.fab.performClick())
                 .setActionTextColor(actionTextColor)
                 .show();
+    }
+
+    @Override
+    public void onOverScroll() {
+        getActivity().finish();
+        getActivity().overridePendingTransition(0, 0);
     }
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/SessionDetailViewModel.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/SessionDetailViewModel.java
@@ -157,6 +157,10 @@ public class SessionDetailViewModel extends BaseObservable implements ViewModel 
         }
     }
 
+    public void onOverScroll() {
+        callback.onOverScroll();
+    }
+
     private String decideSessionTimeRange(Context context, Session session) {
         Date displaySTime = LocaleUtil.getDisplayDate(session.stime, context);
         Date displayETime = LocaleUtil.getDisplayDate(session.etime, context);
@@ -218,5 +222,7 @@ public class SessionDetailViewModel extends BaseObservable implements ViewModel 
     public interface Callback {
 
         void onClickFab(boolean selected);
+
+        void onOverScroll();
     }
 }

--- a/app/src/main/res/layout/fragment_session_detail.xml
+++ b/app/src/main/res/layout/fragment_session_detail.xml
@@ -13,10 +13,11 @@
                 />
     </data>
 
-    <android.support.design.widget.CoordinatorLayout
+    <io.github.droidkaigi.confsched2017.view.customview.OverScrollLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:fitsSystemWindows="true"
+            app:onOverScroll="@{viewModel::onOverScroll}"
             >
 
         <android.support.design.widget.AppBarLayout
@@ -76,10 +77,10 @@
 
                 <android.support.v7.widget.Toolbar
                         android:id="@+id/toolbar"
+                        style="@style/BaseToolbar"
                         android:layout_width="match_parent"
                         android:layout_height="?attr/actionBarSize"
                         android:background="?attr/selectableItemBackground"
-                        style="@style/BaseToolbar"
                         app:layout_collapseMode="pin"
                         />
 
@@ -301,6 +302,6 @@
                 app:topicVividColor="@{viewModel.sessionVividColorResId}"
                 />
 
-    </android.support.design.widget.CoordinatorLayout>
+    </io.github.droidkaigi.confsched2017.view.customview.OverScrollLayout>
 
 </layout>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -35,6 +35,11 @@
         <item name="windowActionBar">false</item>
     </style>
 
+    <style name="AppTheme.Translucent.Half">
+        <item name="android:windowBackground">@color/black_alpha_54</item>
+    </style>
+
+
     <style name="DialogTheme" parent="Theme.AppCompat.Light.Dialog">
         <item name="colorAccent">@color/theme</item>
     </style>


### PR DESCRIPTION
## Issue
- https://github.com/DroidKaigi/conference-app-2017/issues/228

## Overview (Required)
- Finish SessionDetailActivity when page overscrolled

## Links
- none

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/7804631/23058815/0cacb420-f53a-11e6-9fad-7e1c17caae28.gif" width="300" />
