### PR TITLE
Fix doubled session title

### DIFF
--- a/app/src/main/res/layout/fragment_session_detail.xml
+++ b/app/src/main/res/layout/fragment_session_detail.xml
@@ -56,7 +56,7 @@
                             android:fitsSystemWindows="true"
                             android:scaleType="centerCrop"
                             android:src="@drawable/img_session_cover"
-                            android:tint="@color/black_alpha_30"
+                            android:tint="@color/black_alpha_12"
                             />
 
                     <View

--- a/app/src/main/res/layout/fragment_session_detail.xml
+++ b/app/src/main/res/layout/fragment_session_detail.xml
@@ -56,6 +56,7 @@
                             android:fitsSystemWindows="true"
                             android:scaleType="centerCrop"
                             android:src="@drawable/img_session_cover"
+                            android:tint="@color/black_alpha_30"
                             />
 
                     <View

--- a/app/src/main/res/values/styles_session.xml
+++ b/app/src/main/res/values/styles_session.xml
@@ -4,8 +4,6 @@
     <style name="SessionDetailExpandedToolbarTitle">
         <item name="android:textSize">@dimen/text_24sp</item>
         <item name="fontPath">@string/font_noto_cjk_medium</item>
-        <item name="android:shadowColor">@color/black</item>
-        <item name="android:shadowRadius">1</item>
         <item name="android:textColor">@color/white</item>
         <item name="android:maxLines">4</item>
     </style>


### PR DESCRIPTION
## Issue
- #336 

## Overview (Required)
- Remove shadow from session title.
- Add black alpha tint to background image. (Is it correct?)

## Links
None

## Screenshot
Before | After (upper: 12, lower: 30)
:--: | :--:
<img src="https://cloud.githubusercontent.com/assets/1498691/23067282/e8edf7ec-f561-11e6-98e4-5f826e04c639.png" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/1498691/23068553/7793a604-f567-11e6-8f21-4cfcb2bf5c1c.png" width="300" />
&nbsp;  | <img src="https://cloud.githubusercontent.com/assets/1498691/23066839/d50c1508-f55f-11e6-874b-d09070664a63.png" width="300" />
