### PR TITLE
Using the 'for' statement instead of create new Stream instance.

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/customview/ParticlesAnimationView.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/customview/ParticlesAnimationView.java
@@ -60,8 +60,8 @@ public class ParticlesAnimationView extends View {
     @Override
     protected void onDraw(Canvas canvas) {
         super.onDraw(canvas);
-        Stream.of(particles).forEach(particle -> particle.draw(canvas, paint));
-        Stream.of(createLines(particles)).forEach(line -> line.draw(canvas, paint));
+        for (Particle particle : particles) { particle.draw(canvas, paint); }
+        for (Line line : createLines(particles)) { line.draw(canvas, paint); }
     }
 
     private void setGradientBackground() {


### PR DESCRIPTION
## Issue
- https://github.com/DroidKaigi/conference-app-2017/issues/365

## Overview (Required)
- Create new Stream instance every time 'onDraw' is called.
- So using 'for' statement.

## Links
- none
