### PR TITLE
Fix crash in splash when offline

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/SplashActivity.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/SplashActivity.java
@@ -1,11 +1,8 @@
 package io.github.droidkaigi.confsched2017.view.activity;
 
-import android.content.Context;
-import android.content.Intent;
 import android.databinding.DataBindingUtil;
 import android.os.Build;
 import android.os.Bundle;
-import android.os.Handler;
 import android.view.View;
 
 import java.util.Locale;
@@ -22,6 +19,7 @@ import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
+import timber.log.Timber;
 
 public class SplashActivity extends BaseActivity {
 
@@ -73,7 +71,8 @@ public class SplashActivity extends BaseActivity {
                     if (isFinishing()) return;
                     startActivity(MainActivity.createIntent(SplashActivity.this));
                 })
-                .subscribe();
+                .subscribe(objectObservable -> Timber.tag(TAG).d("Succeeded in loading sessions."),
+                        throwable -> Timber.tag(TAG).e(throwable, "Failed to load sessions."));
         compositeDisposable.add(disposable);
     }
 

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/SplashActivity.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/SplashActivity.java
@@ -71,7 +71,7 @@ public class SplashActivity extends BaseActivity {
                     if (isFinishing()) return;
                     startActivity(MainActivity.createIntent(SplashActivity.this));
                 })
-                .subscribe(objectObservable -> Timber.tag(TAG).d("Succeeded in loading sessions."),
+                .subscribe(observable -> Timber.tag(TAG).d("Succeeded in loading sessions."),
                         throwable -> Timber.tag(TAG).e(throwable, "Failed to load sessions."));
         compositeDisposable.add(disposable);
     }


### PR DESCRIPTION
## Issue
none

## Overview (Required)
Since the app has no error handling in `loadSessionsForCache()`, it crashes when fails to load sessions in splash. 💥 
I added only logs using Timber.
I think that we need to implement session reloading function in the future.

## Links
none

## Screenshot
none