### PR TITLE
Update retrofit 2.1.0 -> 2.2.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -184,9 +184,9 @@ dependencies {
     compile 'com.google.firebase:firebase-crash:10.0.1'
 
     // Network
-    compile 'com.squareup.retrofit2:retrofit:2.1.0'
-    compile 'com.jakewharton.retrofit:retrofit2-rxjava2-adapter:1.0.0'
-    compile 'com.squareup.retrofit2:converter-gson:2.1.0'
+    compile 'com.squareup.retrofit2:retrofit:2.2.0'
+    compile 'com.squareup.retrofit2:adapter-rxjava2:2.2.0'
+    compile 'com.squareup.retrofit2:converter-gson:2.2.0'
     compile 'com.google.code.gson:gson:2.8.0'
     compile 'com.squareup.okhttp3:okhttp:3.4.1'
 

--- a/app/licenses.yml
+++ b/app/licenses.yml
@@ -48,11 +48,6 @@
   license: Apache 2.0
   licenseUrl: http://www.apache.org/licenses/LICENSE-2.0.txt
   url: http://github.com/JakeWharton/flip-tables/
-- artifact: com.jakewharton.retrofit:retrofit2-rxjava2-adapter:+
-  name: Retrofit 2 OkHttp 2 Adapter
-  copyrightHolder: Jake Wharton
-  license: Apache License Version 2.0
-  licenseUrl: http://www.apache.org/licenses/LICENSE-2.0.txt
 - artifact: com.jakewharton.timber:timber:+
   name: Timber
   copyrightHolder: Jake Wharton

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/di/AppModule.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/di/AppModule.java
@@ -3,8 +3,6 @@ package io.github.droidkaigi.confsched2017.di;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
-import com.jakewharton.retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
-
 import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -23,6 +21,7 @@ import io.reactivex.disposables.CompositeDisposable;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import retrofit2.Retrofit;
+import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
 import retrofit2.converter.gson.GsonConverterFactory;
 
 /**


### PR DESCRIPTION
## Overview

I have updated retrofit library version 2.1.0 -> 2.2.0.
This allows us to remove Jake's retrofit2-rxjava2-adapter dependency as retrofit itself now officially supports rxjava2-adapter. :eagle: 

reference: https://github.com/square/retrofit/blob/master/CHANGELOG.md#version-220-2017-02-21