### PR TITLE
Tweak circle.yml to collect test metadata.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -29,6 +29,9 @@ test:
     - ./gradlew checkLicenses
     - ./gradlew jacocoTestReportDevelop
     - find . -name app*debug.apk -exec cp {} $CIRCLE_ARTIFACTS/ \;
+  post:
+    - mkdir -p $CIRCLE_TEST_REPORTS/junit/
+    - find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
 
 deployment:
   production:


### PR DESCRIPTION
## Issue
Circle CI informs us that test metadata are not found.
(see a screenshot below)

## Overview (Required)

- JUnit XML files are copied from `app/build/test-results/` to `$CIRCLE_TEST_REPORTS/junit/`

## Links
- https://circleci.com/docs/1.0/test-metadata/#gradle-junit-results

## Screenshot

<img src="https://cloud.githubusercontent.com/assets/3140018/23261660/b7309490-fa1a-11e6-9a5d-70ecf921ec24.png" width="600" />

