### PR TITLE
Make the status bar transparent on SessionDetailActivity

### DIFF
--- a/app/src/main/res/values-v21/themes.xml
+++ b/app/src/main/res/values-v21/themes.xml
@@ -21,4 +21,9 @@
         <item name="android:statusBarColor">@android:color/transparent</item>
     </style>
 
+    <style name="AppTheme.Translucent.Half">
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:windowBackground">@color/black_alpha_54</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
## Overview (Required)
[This change](https://github.com/DroidKaigi/conference-app-2017/pull/359) caused the color of the status bar to be `dark_theme`.
I fixed the appearance by making it transparent for post-Lollipop. 🌀 

## Screenshot
Before | After
:--: | :--:
<img src="https://cloud.githubusercontent.com/assets/11440952/23265204/5336d53c-fa27-11e6-8512-63510a0eac05.gif" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/11440952/23265203/532eb4ba-fa27-11e6-9e52-aa6342771ae9.gif" width="300" />
