### PR TITLE
Fixed an issue that group notification remains

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/receiver/NotificationReceiver.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/receiver/NotificationReceiver.java
@@ -61,6 +61,7 @@ public class NotificationReceiver extends BroadcastReceiver {
                     .setSmallIcon(R.drawable.ic_notification)
                     .setLargeIcon(BitmapFactory.decodeResource(context.getResources(), R.mipmap.ic_launcher))
                     .setColor(ContextCompat.getColor(context, R.color.theme))
+                    .setAutoCancel(true)
                     .setGroup(GROUP_NAME)
                     .setGroupSummary(true)
                     .build();


### PR DESCRIPTION
## Issue
- 

## Overview (Required)
- Fixed an issue that group notification remains even if notification is tapped.

## Links
-

## Screenshot
Before | After
:--: | :--:
![device-2017-02-24-153201](https://cloud.githubusercontent.com/assets/900756/23292939/708cd71a-faa6-11e6-8222-4f21b739294b.png) | <img src="" width="300" />
