### PR TITLE
Finish splash activity manually

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/SplashActivity.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/activity/SplashActivity.java
@@ -70,6 +70,7 @@ public class SplashActivity extends BaseActivity {
                 .doFinally(() -> {
                     if (isFinishing()) return;
                     startActivity(MainActivity.createIntent(SplashActivity.this));
+                    SplashActivity.this.finish();
                 })
                 .subscribe(observable -> Timber.tag(TAG).d("Succeeded in loading sessions."),
                         throwable -> Timber.tag(TAG).e(throwable, "Failed to load sessions."));


### PR DESCRIPTION
## Issue
#377

## Overview (Required)
It seems `android:noHistory="true"` doesn't finish the activity if user tap back button right after launching new activity.

## Links
I couldn't find this behavior's documentation. 

## Question

Could anyone point me if there is other concern?

## What I did

I tried the following code 

```java
    private void loadSessionsForCache() {
//        Disposable disposable = Single.zip(sessionsRepository.findAll(Locale.getDefault()),
//                mySessionsRepository.findAll(),
//                Single.timer(MINIMUM_LOADING_TIME, TimeUnit.MILLISECONDS),
//                (sessions, mySessions, obj) -> Observable.empty())
//                .subscribeOn(Schedulers.io())
//                .observeOn(AndroidSchedulers.mainThread())
//                .doFinally(() -> {
//                    if (isFinishing()) return;
//                    startActivity(MainActivity.createIntent(SplashActivity.this));
//                    SplashActivity.this.finish();
//                })
//                .subscribe(observable -> Timber.tag(TAG).d("Succeeded in loading sessions."),
//                        throwable -> Timber.tag(TAG).e(throwable, "Failed to load sessions."));
//        compositeDisposable.add(disposable);

        startActivity(MainActivity.createIntent(SplashActivity.this));
    }
```

This become no Splash screen but it still show me Splash screen if I tap back button just after launching session screen. This means Rx has nothing wrong with this behavior.

## Screenshot
Before | After
:--: | :--:
<img src="https://cloud.githubusercontent.com/assets/3675458/23311759/913bb446-fafa-11e6-9a75-302790737196.gif" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/3675458/23311907/135903b6-fafb-11e6-817c-828b1edb922d.gif" width="300" />
