### PR TITLE
Remove Iterator interface

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/customview/ArrayRecyclerAdapter.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/customview/ArrayRecyclerAdapter.java
@@ -7,11 +7,10 @@ import android.support.v7.widget.RecyclerView;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 
 public abstract class ArrayRecyclerAdapter<T, VH extends RecyclerView.ViewHolder>
-        extends RecyclerView.Adapter<VH> implements Iterable<T> {
+        extends RecyclerView.Adapter<VH> {
 
     protected final List<T> list;
 
@@ -69,8 +68,4 @@ public abstract class ArrayRecyclerAdapter<T, VH extends RecyclerView.ViewHolder
         return context;
     }
 
-    @Override
-    public Iterator<T> iterator() {
-        return list.iterator();
-    }
 }


### PR DESCRIPTION
## Issue
#358

## Overview (Required)
Remove `Iterator` interface from `ArrayRecyclerAdapter`

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
