### PR TITLE
Created session feedback page

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/api/DroidKaigiClient.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/api/DroidKaigiClient.java
@@ -31,7 +31,8 @@ public class DroidKaigiClient {
     private static final int MAX_PER_PAGE = 100;
 
     @Inject
-    public DroidKaigiClient(DroidKaigiService droidKaigiService, GithubService githubService, GoogleFormService googleFormService) {
+    public DroidKaigiClient(DroidKaigiService droidKaigiService, GithubService githubService,
+            GoogleFormService googleFormService) {
         this.droidKaigiService = droidKaigiService;
         this.githubService = githubService;
         this.googleFormService = googleFormService;
@@ -49,7 +50,13 @@ public class DroidKaigiClient {
         return githubService.getContributors("DroidKaigi", "conference-app-2017", INCLUDE_ANONYMOUS, MAX_PER_PAGE);
     }
 
-    public Single<Response<Void>>submitSessionFeedback(SessionFeedback sessionFeedback){
-        return googleFormService.submitSessionFeedback(sessionFeedback.sessionId);
+    public Single<Response<Void>> submitSessionFeedback(@NonNull SessionFeedback sessionFeedback) {
+        return googleFormService.submitSessionFeedback(sessionFeedback.sessionId,
+                sessionFeedback.sessionTitle,
+                sessionFeedback.relevancy,
+                sessionFeedback.asExpected,
+                sessionFeedback.difficulty,
+                sessionFeedback.knowledgeable,
+                sessionFeedback.comment);
     }
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/api/service/GoogleFormService.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/api/service/GoogleFormService.java
@@ -8,9 +8,15 @@ import retrofit2.http.POST;
 
 public interface GoogleFormService {
 
-    // TODO: change test url and add form item
-    @POST("1FAIpQLSeSr-Tn3TnNum2md8l3jCZa0cnMYMXXaouHomubecdaRlGFCQ/formResponse")
+    @POST("e/1FAIpQLSf5NydpYm48GXqlKqbG3e0dna3bw5HJ4GUg8W1Yfe4znTWH_g/formResponse")
     @FormUrlEncoded
-    Single<Response<Void>> submitSessionFeedback(@Field("entry.684428626") int id);
+    Single<Response<Void>> submitSessionFeedback(
+            @Field("entry.1298546024") int sessionId,
+            @Field("entry.413792998") String sessionTitle,
+            @Field("entry.335146475") int relevancy,
+            @Field("entry.1916895481") int asExpected,
+            @Field("entry.1501292277") int difficulty,
+            @Field("entry.2121897737") int knowledgeable,
+            @Field("entry.645604473") String comment);
 
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/model/SessionFeedback.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/model/SessionFeedback.java
@@ -1,9 +1,41 @@
 package io.github.droidkaigi.confsched2017.model;
 
+import com.google.gson.annotations.SerializedName;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
 public class SessionFeedback {
+
+    @SerializedName("entry.1298546024")
     public final int sessionId;
 
-    public SessionFeedback(int sessionId) {
-        this.sessionId = sessionId;
+    @SerializedName("entry.413792998")
+    public final String sessionTitle;
+
+    @SerializedName("entry.335146475")
+    public final int relevancy;
+
+    @SerializedName("entry.1916895481")
+    public final int asExpected;
+
+    @SerializedName("entry.1501292277")
+    public final int difficulty;
+
+    @SerializedName("entry.2121897737")
+    public final int knowledgeable;
+
+    @SerializedName("entry.645604473")
+    public final String comment;
+
+    public SessionFeedback(@NonNull Session session, int relevancy, int asExpected,
+            int difficulty, int knowledgeable, @Nullable String comment) {
+        this.sessionId = session.id;
+        this.sessionTitle = session.title;
+        this.relevancy = relevancy;
+        this.asExpected = asExpected;
+        this.difficulty = difficulty;
+        this.knowledgeable = knowledgeable;
+        this.comment = comment;
     }
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/repository/feedbacks/SessionFeedbackRemoteDataSource.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/repository/feedbacks/SessionFeedbackRemoteDataSource.java
@@ -17,6 +17,6 @@ public class SessionFeedbackRemoteDataSource {
     }
 
     public Single<Response<Void>> submit(SessionFeedback sessionFeedback) {
-       return client.submitSessionFeedback(sessionFeedback);
+        return client.submitSessionFeedback(sessionFeedback);
     }
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SessionFeedbackFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/view/fragment/SessionFeedbackFragment.java
@@ -14,13 +14,7 @@ import android.widget.Toast;
 import javax.inject.Inject;
 
 import io.github.droidkaigi.confsched2017.databinding.FragmentSessionFeedbackBinding;
-import io.github.droidkaigi.confsched2017.model.SessionFeedback;
 import io.github.droidkaigi.confsched2017.viewmodel.SessionFeedbackViewModel;
-import io.reactivex.android.schedulers.AndroidSchedulers;
-import io.reactivex.disposables.CompositeDisposable;
-import io.reactivex.disposables.Disposable;
-import io.reactivex.schedulers.Schedulers;
-import timber.log.Timber;
 
 @FragmentCreator
 public class SessionFeedbackFragment extends BaseFragment implements SessionFeedbackViewModel.Callback {
@@ -29,9 +23,6 @@ public class SessionFeedbackFragment extends BaseFragment implements SessionFeed
 
     @Inject
     SessionFeedbackViewModel viewModel;
-
-    @Inject
-    CompositeDisposable compositeDisposable;
 
     @Args
     int sessionId;
@@ -46,6 +37,7 @@ public class SessionFeedbackFragment extends BaseFragment implements SessionFeed
         super.onCreate(savedInstanceState);
         SessionFeedbackFragmentCreator.read(this);
         viewModel.setCallback(this);
+        viewModel.findSession(sessionId);
     }
 
     @Override
@@ -59,28 +51,7 @@ public class SessionFeedbackFragment extends BaseFragment implements SessionFeed
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         binding = FragmentSessionFeedbackBinding.inflate(inflater, container, false);
         binding.setViewModel(viewModel);
-
-        initView();
         return binding.getRoot();
-    }
-
-    private void initView() {
-        Disposable disposable = viewModel.findSession(sessionId)
-                .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(
-                        session -> {
-                            // TODO
-                        },
-                        throwable -> Timber.tag(TAG).e(throwable, "Failed to find session.")
-                );
-        compositeDisposable.add(disposable);
-    }
-
-    @Override
-    public void onPause() {
-        super.onPause();
-        compositeDisposable.dispose();
     }
 
     @Override
@@ -90,26 +61,13 @@ public class SessionFeedbackFragment extends BaseFragment implements SessionFeed
     }
 
     @Override
-    public void onDetach() {
-        super.onDetach();
-        compositeDisposable.clear();
-    }
-
-    @Override
-    public void onClickSubmitFeedback() {
-        SessionFeedback sessionFeedback = new SessionFeedback(sessionId);
-        compositeDisposable.add(viewModel.submitSessionFeedback(sessionFeedback)
-                .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(success -> onSubmitSuccess(), failure -> onSubmitFailure()));
-    }
-
-    public void onSubmitSuccess() {
+    public void onSuccessSubmit() {
         // TODO: show success action
         Toast.makeText(getContext(), "submit success", Toast.LENGTH_SHORT).show();
     }
 
-    public void onSubmitFailure() {
+    @Override
+    public void onErrorSubmit() {
         // TODO: show failure action
         Toast.makeText(getContext(), "submit failure", Toast.LENGTH_SHORT).show();
     }

--- a/app/src/main/res/layout/fragment_session_feedback.xml
+++ b/app/src/main/res/layout/fragment_session_feedback.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
-        xmlns:tools="http://schemas.android.com/tools"
         >
 
     <data>
@@ -15,7 +14,7 @@
     <ScrollView
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:background="@color/grey50"
+            android:background="@color/grey200"
             >
 
         <LinearLayout
@@ -25,10 +24,10 @@
                 android:padding="@dimen/space_8dp"
                 >
 
-            <!-- TODO This is sample item -->
+            <!-- Relevancy -->
             <android.support.v7.widget.CardView style="@style/BaseCardView">
 
-                <RelativeLayout
+                <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:orientation="vertical"
@@ -36,30 +35,149 @@
                         >
 
                     <TextView
-                            android:id="@+id/txt_feedback_1"
                             style="@style/FeedbackTitle"
-                            android:text="Did you enjoy this session?"
-                            tools:ignore="HardcodedText"
+                            android:text="@string/session_feedback_relevancy_title"
                             />
 
                     <io.github.droidkaigi.confsched2017.view.customview.FeedbackRankingView
-                            android:id="@+id/feedback_ranking_1"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_below="@id/txt_feedback_1"
                             android:layout_marginTop="@dimen/space_16dp"
-                            app:currentRanking="@={viewModel.ranking1}"
-                            app:rankingLabelEnd="Excellent"
-                            app:rankingLabelStart="No"
+                            app:currentRanking="@={viewModel.relevancy}"
+                            app:rankingLabelEnd="@string/session_feedback_relevancy_max_text"
+                            app:rankingLabelStart="@string/session_feedback_relevancy_min_text"
                             />
 
-                </RelativeLayout>
+                </LinearLayout>
+
+            </android.support.v7.widget.CardView>
+
+            <!-- As expected -->
+            <android.support.v7.widget.CardView
+                    style="@style/BaseCardView"
+                    android:layout_marginTop="@dimen/space_4dp"
+                    >
+
+                <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"
+                        android:padding="@dimen/space_16dp"
+                        >
+
+                    <TextView
+                            style="@style/FeedbackTitle"
+                            android:text="@string/session_feedback_asexpected_title"
+                            />
+
+                    <io.github.droidkaigi.confsched2017.view.customview.FeedbackRankingView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/space_16dp"
+                            app:currentRanking="@={viewModel.asExpected}"
+                            app:rankingLabelEnd="@string/session_feedback_asexpected_max_text"
+                            app:rankingLabelStart="@string/session_feedback_asexpected_min_text"
+                            />
+
+                </LinearLayout>
+
+            </android.support.v7.widget.CardView>
+
+            <!-- Difficulty -->
+            <android.support.v7.widget.CardView
+                    style="@style/BaseCardView"
+                    android:layout_marginTop="@dimen/space_4dp"
+                    >
+
+                <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"
+                        android:padding="@dimen/space_16dp"
+                        >
+
+                    <TextView
+                            style="@style/FeedbackTitle"
+                            android:text="@string/session_feedback_difficulty_title"
+                            />
+
+                    <io.github.droidkaigi.confsched2017.view.customview.FeedbackRankingView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/space_16dp"
+                            app:currentRanking="@={viewModel.difficulty}"
+                            app:rankingLabelEnd="@string/session_feedback_difficulty_max_text"
+                            app:rankingLabelStart="@string/session_feedback_difficulty_min_text"
+                            />
+
+                </LinearLayout>
+
+            </android.support.v7.widget.CardView>
+
+            <!-- Knowledgeable -->
+            <android.support.v7.widget.CardView
+                    style="@style/BaseCardView"
+                    android:layout_marginTop="@dimen/space_4dp"
+                    >
+
+                <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"
+                        android:padding="@dimen/space_16dp"
+                        >
+
+                    <TextView
+                            style="@style/FeedbackTitle"
+                            android:text="@string/session_feedback_knowledgeable_title"
+                            />
+
+                    <io.github.droidkaigi.confsched2017.view.customview.FeedbackRankingView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/space_16dp"
+                            app:currentRanking="@={viewModel.knowledgeable}"
+                            app:rankingLabelEnd="@string/session_feedback_knowledgeable_max_text"
+                            app:rankingLabelStart="@string/session_feedback_knowledgeable_min_text"
+                            />
+
+                </LinearLayout>
+
+            </android.support.v7.widget.CardView>
+
+
+            <!-- Comment -->
+            <android.support.v7.widget.CardView
+                    style="@style/BaseCardView"
+                    android:layout_marginTop="@dimen/space_4dp"
+                    >
+
+                <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"
+                        android:padding="@dimen/space_16dp"
+                        >
+
+                    <TextView
+                            style="@style/FeedbackTitle"
+                            android:text="@string/session_feedback_comment_title"
+                            />
+
+                    <EditText
+                            style="@style/BaseEditText"
+                            android:layout_marginTop="@dimen/space_16dp"
+                            android:hint="@string/session_feedback_comment_hint"
+                            android:text="@={viewModel.comment}"
+                            />
+
+                </LinearLayout>
 
             </android.support.v7.widget.CardView>
 
             <Button
                     android:id="@+id/submit_feedback"
-                    style="@style/Button.Grey"
+                    style="@style/Button.Purple"
                     android:layout_marginTop="@dimen/space_8dp"
                     android:onClick="@{viewModel::onClickSubmitFeedbackButton}"
                     android:text="@string/send_feedback"

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -63,7 +63,26 @@
     <!-- Licenses -->
     <string name="licenses">オープンソースライセンス</string>
     <!-- Session feedback -->
+    <string name="session_feedback_relevancy_title">このセッションはあなたの仕事やプロジェクトに関連がありましたか？</string>
+    <string name="session_feedback_relevancy_min_text">ほとんど関連がない</string>
+    <string name="session_feedback_relevancy_max_text">非常に関連がある</string>
+    <string name="session_feedback_asexpected_title">セッションの説明を読んで期待した通りの内容でしたか？</string>
+    <string name="session_feedback_asexpected_min_text">期待外れ</string>
+    <string name="session_feedback_asexpected_max_text">期待以上</string>
+    <string name="session_feedback_difficulty_title">セッションの難易度はいかがでしたか？</string>
+    <string name="session_feedback_difficulty_min_text">基本的すぎた</string>
+    <string name="session_feedback_difficulty_max_text">高度すぎた</string>
+    <string name="session_feedback_knowledgeable_title">技術的な知見は得られたでしょうか？</string>
+    <string name="session_feedback_knowledgeable_min_text">あまり知見はなかった</string>
+    <string name="session_feedback_knowledgeable_max_text">知見に溢れていた</string>
+    <string name="session_feedback_comment_title">他にコメントがあればぜひ教えてください（個人が特定できるような内容は書かないでください）</string>
+    <string name="session_feedback_comment_hint">回答を入力</string>
     <string name="session_feedback">セッションフィードバック</string>
+    <string name="session_feedback_accepted_successfully">ありがとうございます！フィードバックは送信されました。</string>
+    <string name="session_feedback_not_accepting">申し訳ありません。DroidKaigi終了から日にちが経っているため現在はフィードバックを送信できません。</string>
+    <string name="session_feedback_submit_error">送信中にエラーが発生しました。ネットワーク状態を確認してもう一度お試しください。</string>
+    <string name="session_feedback_submit_failure">送信に失敗しました。</string>
+    <string name="session_feedback_submit_success">送信しました。</string>
     <!-- Notification -->
     <string name="notification_title">%1$s がもうすぐ始まります。</string>
     <string name="notification_message">%1$s ~ %2$s @ %3$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,7 +100,27 @@
     <string name="licenses">Licenses</string>
 
     <!-- Session feedback -->
+    <string name="session_feedback_relevancy_title">How relevant was this session to your projects?</string>
+    <string name="session_feedback_relevancy_min_text">Not at all</string>
+    <string name="session_feedback_relevancy_max_text">Extremely</string>
+    <string name="session_feedback_asexpected_title">Based on the description, was the content as expected?</string>
+    <string name="session_feedback_asexpected_min_text">Below</string>
+    <string name="session_feedback_asexpected_max_text">Beyond</string>
+    <string name="session_feedback_difficulty_title">Was this session easy to understand?</string>
+    <string name="session_feedback_difficulty_min_text">Easy</string>
+    <string name="session_feedback_difficulty_max_text">Hard</string>
+    <string name="session_feedback_knowledgeable_title">How knowledgeable was the content?</string>
+    <string name="session_feedback_knowledgeable_min_text">Poor</string>
+    <string name="session_feedback_knowledgeable_max_text">Outstanding</string>
+    <string name="session_feedback_comment_title">Anything else we should know? (Please don\'t add any personal information in your comments)</string>
+    <string name="session_feedback_comment_hint">Other session feedback?</string>
+
     <string name="session_feedback">Session feedback</string>
+    <string name="session_feedback_accepted_successfully">Thank you! The feedback was accepted.</string>
+    <string name="session_feedback_not_accepting">Sorry. Currently we are not accepting the feedback. You can submit feedback only during the event dates.</string>
+    <string name="session_feedback_submit_error">An error occurred while submitting. Make sure the network is available.</string>
+    <string name="session_feedback_submit_failure">Submit failed</string>
+    <string name="session_feedback_submit_success">Submit succeeded</string>
 
     <!-- Search -->
     <string name="search">Search</string>

--- a/app/src/main/res/values/styles_base.xml
+++ b/app/src/main/res/values/styles_base.xml
@@ -50,6 +50,12 @@
         <item name="android:textSize">@dimen/text_16sp</item>
     </style>
 
+    <style name="Button.Purple">
+        <item name="android:layout_width">match_parent</item>
+        <item name="backgroundTint">@color/purple</item>
+        <item name="android:textColor">@color/white</item>
+    </style>
+
     <style name="Button.Grey">
         <item name="android:layout_width">match_parent</item>
         <item name="backgroundTint">@color/grey200</item>
@@ -60,6 +66,16 @@
         <item name="android:layout_width">match_parent</item>
         <item name="backgroundTint">@color/accent</item>
         <item name="android:textColor">@color/white</item>
+    </style>
+
+
+    <!--==================== EditText ====================-->
+    <style name="BaseEditText">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:textAppearance">@style/TextSubheading</item>
+        <item name="android:textColor">@color/black</item>
+        <item name="android:textColorHint">@color/grey600</item>
     </style>
 
 

--- a/app/src/test/java/io/github/droidkaigi/confsched2017/api/DroidKaigiClientTest.kt
+++ b/app/src/test/java/io/github/droidkaigi/confsched2017/api/DroidKaigiClientTest.kt
@@ -6,13 +6,10 @@ import com.sys1yagi.kmockito.verify
 import io.github.droidkaigi.confsched2017.api.service.DroidKaigiService
 import io.github.droidkaigi.confsched2017.api.service.GithubService
 import io.github.droidkaigi.confsched2017.api.service.GoogleFormService
-import io.github.droidkaigi.confsched2017.model.SessionFeedback
 import io.github.droidkaigi.confsched2017.util.DummyCreator
-import io.github.droidkaigi.confsched2017.util.LocaleUtil
 import io.reactivex.Single
 import org.junit.Test
 import org.mockito.Mockito
-import retrofit2.Response
 import java.util.*
 
 class DroidKaigiClientTest {
@@ -61,19 +58,4 @@ class DroidKaigiClientTest {
         }
     }
 
-    @Test
-    @Throws(Exception::class)
-    fun submitSessionFeedback() {
-        val res = Response.success<Void>(null)
-        googleFormService.submitSessionFeedback(0)
-                .invoked.thenReturn(Single.just(res))
-
-        val feedBack = SessionFeedback(0)
-        client.submitSessionFeedback(feedBack).test().run {
-            assertNoErrors()
-            assertValue(res)
-            assertComplete()
-        }
-        googleFormService.verify().submitSessionFeedback(0)
-    }
 }


### PR DESCRIPTION
## Issue
https://github.com/DroidKaigi/conference-app-2017/issues/74

## Overview (Required)
Just created session feedback page.

## Rest tasks
- Prevent double tap.
- Show success message properly.
- Handle submit error.
- Handle network error.
- Show error message when there are empty values.

## Screenshot
English | Japanese
:--: | :--:
<img src="https://cloud.githubusercontent.com/assets/1269214/23607961/5b443892-02aa-11e7-99c6-ecf1174e8895.jpg" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/1269214/23607987/88ae4282-02aa-11e7-8ad9-caa53dfdd0bd.jpg" width="300" />
<img src="https://cloud.githubusercontent.com/assets/1269214/23607970/6a707736-02aa-11e7-8ee4-13a09bc30454.jpg" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/1269214/23608003/96a25c52-02aa-11e7-99ff-cd6b65ff9d8a.jpg" width="300" />