### PR TITLE
Hide developer menu on production build

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/SettingsViewModel.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2017/viewmodel/SettingsViewModel.java
@@ -8,6 +8,7 @@ import android.view.View;
 
 import javax.inject.Inject;
 
+import io.github.droidkaigi.confsched2017.BuildConfig;
 import io.github.droidkaigi.confsched2017.pref.DefaultPrefs;
 import io.github.droidkaigi.confsched2017.util.LocaleUtil;
 
@@ -73,6 +74,10 @@ public final class SettingsViewModel extends BaseObservable implements ViewModel
         if (callback != null) {
             callback.changeHeadsUpEnabled(isChecked);
         }
+    }
+
+    public int getShowDeveloperMenu() {
+        return BuildConfig.FLAVOR.equals("develop") ? View.VISIBLE : View.GONE;
     }
 
     public void onCheckedDebugOverlayView(boolean isChecked) {

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -143,6 +143,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:padding="@dimen/space_16dp"
+                    android:visibility="@{viewModel.showDeveloperMenu}"
                     >
 
                 <TextView
@@ -169,13 +170,14 @@
                     android:id="@+id/debug_overlay_view_switch_row"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:visibility="@{viewModel.showDeveloperMenu}"
                     app:settingDefaultValue="@{viewModel.useDebugOverlayView}"
                     app:settingDescription="@string/settings_debug_overlay_view_description"
                     app:settingOnCheckedChanged="@{(v, checked) -> viewModel.onCheckedDebugOverlayView(checked)}"
                     app:settingTitle="@string/settings_debug_overlay_view"
                     />
 
-            <View style="@style/Border"/>
+            <View style="@style/Border" />
 
         </LinearLayout>
 


### PR DESCRIPTION
## Issue
- None

## Overview (Required)
- Hide developer menu on production build.

## Screenshot
Before | After
:--: | :--:
<img src="https://cloud.githubusercontent.com/assets/1316988/23637565/ce340056-031f-11e7-972b-85315e120fa3.jpg" width="300" /> | <img src="https://cloud.githubusercontent.com/assets/1316988/23637588/e3df3fe2-031f-11e7-8238-a8514b7d5b96.jpg" width="300" />
