### PR TITLE
adapt launch mode = singleTask for MainActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,6 +36,7 @@
         <activity
                 android:name=".view.activity.MainActivity"
                 android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation"
+                android:launchMode="singleTask"
                 />
 
         <activity


### PR DESCRIPTION
## Issue
- #409 

## Overview (Required)
- MainActivity's instance is re-created many times because there are no launch mode specified. 
- We can overlap the same MainActivity eternally. 

## Links
- [ActivityのlaunchModeの効果的な使い方](http://qiita.com/kskso9/items/1ee5b1dbe996402ae94b)

## How to Re-generate
- Launch App from Home
- press the OS home button
- Launch App from the icon again. 
- press the OS back button. 

## Screenshot
nothing but test manually